### PR TITLE
Remove hooks/hooks.json from plugin.json as is it is loaded automatically

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,6 +12,5 @@
     "commands": [
         "./commands/notifications-init.md",
         "./commands/notifications-settings.md"
-    ],
-    "hooks": ["./hooks/hooks.json"]
+    ]
 }


### PR DESCRIPTION
Seems hooks/hooks.json is now loaded automatically, so claude code was giving an error:

```
 Plugin Errors
 └ 1 plugin error(s) detected:
   └ claude-notifications-go@claude-notifications-go [claude-notifications-go]: Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file 
 /home/ismael/.claude/plugins/marketplaces/claude-notifications-go/hooks/hooks.json. The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only reference additional hook files.
```

This change fixes the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused hooks configuration from the plugin descriptor, streamlining the plugin structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->