### PR TITLE
feat: add double-shot-latte compatibility - suppress notifications in background judge mode (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Smart notifications for Claude Code with click-to-focus, git branch display, and
     - [🔊 Audio Customization](#-audio-customization)
     - [🌐 Enterprise-Grade Webhooks](#-enterprise-grade-webhooks)
     - [🛠️ Developer Experience](#️-developer-experience)
+    - [🤝 Plugin Compatibility](#-plugin-compatibility)
   - [Platform Support](#platform-support)
     - [macOS Click-to-Focus](#macos-click-to-focus)
   - [Quick Start](#quick-start)
@@ -148,6 +149,14 @@ Your `config.json` settings will be preserved during the update.
 - **Stop/SubagentStop hooks** analyze the conversation transcript using a state machine to determine the task status
 - **Notification hook** is triggered when Claude needs user input (permission dialogs, questions)
 - The state machine uses temporal locality (last 15 messages) and tool analysis to accurately detect task completion
+
+### 🤝 Plugin Compatibility
+
+Compatible with other Claude Code plugins that spawn background Claude instances:
+
+- **[double-shot-latte](https://github.com/obra/double-shot-latte)** - Auto-continue plugin that uses a background Claude instance for context evaluation. Notifications are automatically suppressed for the background judge process (via `CLAUDE_HOOK_JUDGE_MODE=true` environment variable).
+
+If you're developing a plugin that spawns background Claude instances and want to suppress notifications, set `CLAUDE_HOOK_JUDGE_MODE=true` in the environment before invoking Claude.
 
 ## Platform Support
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -80,6 +80,13 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 	// Add panic recovery for robustness
 	defer errorhandler.HandlePanic()
 
+	// Skip notifications when running in background judge mode (e.g., double-shot-latte plugin)
+	// The CLAUDE_HOOK_JUDGE_MODE env var is set by plugins that spawn background Claude instances
+	// to evaluate context/decide on continuation - we don't want notifications from these
+	if os.Getenv("CLAUDE_HOOK_JUDGE_MODE") == "true" {
+		return nil
+	}
+
 	// Ensure notifier resources are cleaned up when function exits
 	defer func() {
 		if err := h.notifierSvc.Close(); err != nil {


### PR DESCRIPTION
## Summary

This PR adds compatibility with the [double-shot-latte](https://github.com/obra/double-shot-latte) plugin, which spawns background Claude instances for context evaluation. Previously, these background instances would trigger unwanted notifications.

## Changes

### Core Implementation (`internal/hooks/hooks.go`)
- Added early exit check for `CLAUDE_HOOK_JUDGE_MODE=true` environment variable
- When double-shot-latte runs its background Claude judge, it sets this env var
- The notification plugin now silently exits without sending any notifications in this mode

### Tests (`internal/hooks/hooks_test.go`)
- `TestHandler_SkipsNotificationsInJudgeMode` - verifies notifications are suppressed when `CLAUDE_HOOK_JUDGE_MODE=true`
- `TestHandler_SendsNotificationsWhenJudgeModeNotSet` - verifies normal operation without the env var
- `TestHandler_SendsNotificationsWhenJudgeModeFalse` - verifies notifications work when env var is "false"
- Updated `newTestHandler` to clear `CLAUDE_HOOK_JUDGE_MODE` by default for test isolation

### Documentation (`README.md`)
- Added new **🤝 Plugin Compatibility** section under Features
- Documented compatibility with double-shot-latte
- Added guidance for other plugin developers who spawn background Claude instances

## Why This Change?

A user reported that when using both plugins together:
1. double-shot-latte would spawn a background Claude instance for context evaluation
2. This background instance would trigger notifications even though the user wasn't interacting with it
3. This caused confusion and notification spam

## Technical Details

The solution leverages the `CLAUDE_HOOK_JUDGE_MODE=true` environment variable that double-shot-latte already sets when spawning its judge Claude instance. This is a clean, zero-configuration solution - users simply update the notification plugin and it works automatically.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added judge mode functionality to suppress notifications when used alongside other Claude plugins that spawn background instances.

* **Documentation**
  * Added plugin compatibility section documenting how to enable judge mode using the CLAUDE_HOOK_JUDGE_MODE environment variable for multi-plugin environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->