### PR TITLE
feat(macos): add tmux pane focus on notification click

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type DesktopConfig struct {
 	AudioDevice      string  `json:"audioDevice"`      // Audio output device name (empty = system default)
 	AppIcon          string  `json:"appIcon"`          // Path to app icon
 	ClickToFocus     bool    `json:"clickToFocus"`     // macOS: activate terminal on notification click (default: true)
+	TmuxPaneFocus    bool    `json:"tmuxPaneFocus"`    // macOS+tmux: navigate to exact pane on notification click (default: true)
 	TerminalBundleID string  `json:"terminalBundleId"` // macOS: override auto-detected terminal bundle ID (empty = auto)
 }
 
@@ -89,11 +90,12 @@ func DefaultConfig() *Config {
 	return &Config{
 		Notifications: NotificationsConfig{
 			Desktop: DesktopConfig{
-				Enabled:      true,
-				Sound:        true,
-				Volume:       1.0, // Full volume by default
-				AppIcon:      filepath.Join(pluginRoot, "claude_icon.png"),
-				ClickToFocus: true, // macOS: activate terminal on click (default: enabled)
+				Enabled:       true,
+				Sound:         true,
+				Volume:        1.0, // Full volume by default
+				AppIcon:       filepath.Join(pluginRoot, "claude_icon.png"),
+				ClickToFocus:  true, // macOS: activate terminal on click (default: enabled)
+				TmuxPaneFocus: true, // macOS+tmux: navigate to exact pane on click (default: enabled)
 				// TerminalBundleID: "" - empty means auto-detect
 			},
 			Webhook: WebhookConfig{

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -92,6 +92,7 @@ func (n *Notifier) SendDesktop(status analyzer.Status, message string) error {
 
 // sendWithTerminalNotifier sends notification via terminal-notifier on macOS
 // with click-to-focus support (clicking notification activates the terminal)
+// When running inside tmux, clicking the notification will navigate to the exact pane
 func (n *Notifier) sendWithTerminalNotifier(title, message string) error {
 	notifierPath, err := GetTerminalNotifierPath()
 	if err != nil {
@@ -99,7 +100,18 @@ func (n *Notifier) sendWithTerminalNotifier(title, message string) error {
 	}
 
 	bundleID := GetTerminalBundleID(n.cfg.Notifications.Desktop.TerminalBundleID)
-	args := buildTerminalNotifierArgs(title, message, bundleID)
+	
+	// Check if we're running inside tmux
+	tmuxPane := GetCurrentTmuxPane()
+	
+	var args []string
+	if tmuxPane != nil && n.cfg.Notifications.Desktop.TmuxPaneFocus {
+		// Use -execute to run tmux navigation command when clicked
+		args = buildTerminalNotifierArgsWithTmux(title, message, bundleID, tmuxPane)
+	} else {
+		// Standard behavior: just activate the terminal app
+		args = buildTerminalNotifierArgs(title, message, bundleID)
+	}
 
 	cmd := exec.Command(notifierPath, args...)
 
@@ -108,7 +120,11 @@ func (n *Notifier) sendWithTerminalNotifier(title, message string) error {
 		return fmt.Errorf("terminal-notifier error: %w, output: %s", err, string(output))
 	}
 
-	logging.Debug("terminal-notifier executed: bundleID=%s", bundleID)
+	if tmuxPane != nil {
+		logging.Debug("terminal-notifier executed: bundleID=%s, tmuxPane=%s", bundleID, tmuxPane.Target)
+	} else {
+		logging.Debug("terminal-notifier executed: bundleID=%s", bundleID)
+	}
 	return nil
 }
 
@@ -122,6 +138,25 @@ func buildTerminalNotifierArgs(title, message, bundleID string) []string {
 		// Note: -sender option removed because it conflicts with -activate on macOS Sequoia (15.x)
 		// Using -sender causes click-to-focus to stop working.
 		// Trade-off: no custom Claude icon, but click-to-focus works reliably.
+	}
+
+	// Add group ID to prevent notification stacking issues
+	args = append(args, "-group", fmt.Sprintf("claude-notif-%d", time.Now().UnixNano()))
+
+	return args
+}
+
+// buildTerminalNotifierArgsWithTmux constructs arguments that include tmux pane navigation.
+// When the notification is clicked, it will switch to the exact tmux pane that triggered it.
+func buildTerminalNotifierArgsWithTmux(title, message, bundleID string, pane *TmuxPaneInfo) []string {
+	focusCmd := BuildTmuxFocusCommand(pane, bundleID)
+
+	args := []string{
+		"-title", title,
+		"-message", message,
+		"-execute", focusCmd,
+		// Note: -execute is mutually exclusive with -activate
+		// The focus command handles both tmux navigation AND terminal activation
 	}
 
 	// Add group ID to prevent notification stacking issues

--- a/internal/notifier/tmux_darwin.go
+++ b/internal/notifier/tmux_darwin.go
@@ -1,0 +1,88 @@
+//go:build darwin
+
+package notifier
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/777genius/claude-notifications/internal/logging"
+)
+
+// TmuxPaneInfo contains the current tmux pane details for click-to-focus navigation
+type TmuxPaneInfo struct {
+	SessionName string // tmux session name
+	WindowIndex string // window index within session
+	PaneIndex   string // pane index within window
+	Target      string // full target string like "session:0.1"
+}
+
+// GetCurrentTmuxPane detects if we're running inside tmux and returns the current pane info.
+// Returns nil if not in a tmux session.
+func GetCurrentTmuxPane() *TmuxPaneInfo {
+	// Check if we're inside tmux
+	if os.Getenv("TMUX") == "" {
+		return nil
+	}
+
+	// Get the full pane target in format "session_name:window_index.pane_index"
+	cmd := exec.Command("tmux", "display-message", "-p", "#{session_name}:#{window_index}.#{pane_index}")
+	output, err := cmd.Output()
+	if err != nil {
+		logging.Debug("Failed to get tmux pane info: %v", err)
+		return nil
+	}
+
+	target := strings.TrimSpace(string(output))
+	if target == "" {
+		return nil
+	}
+
+	// Parse the target string
+	// Format: "session_name:window_index.pane_index" (e.g., "main:0.2")
+	parts := strings.SplitN(target, ":", 2)
+	if len(parts) != 2 {
+		logging.Debug("Unexpected tmux target format: %s", target)
+		return nil
+	}
+
+	sessionName := parts[0]
+	windowPane := parts[1]
+
+	wpParts := strings.SplitN(windowPane, ".", 2)
+	if len(wpParts) != 2 {
+		logging.Debug("Unexpected tmux window.pane format: %s", windowPane)
+		return nil
+	}
+
+	info := &TmuxPaneInfo{
+		SessionName: sessionName,
+		WindowIndex: wpParts[0],
+		PaneIndex:   wpParts[1],
+		Target:      target,
+	}
+
+	logging.Debug("Detected tmux pane: %s", target)
+	return info
+}
+
+// BuildTmuxFocusCommand builds a shell command that will:
+// 1. Switch to the correct tmux session/window/pane
+// 2. Activate the terminal application
+func BuildTmuxFocusCommand(pane *TmuxPaneInfo, terminalBundleID string) string {
+	if pane == nil {
+		return ""
+	}
+
+	// Use switch-client for attached sessions, or attach if detached
+	// Also select the specific window and pane
+	// Finally, bring the terminal app to front with 'open -b'
+	cmd := "tmux switch-client -t '" + pane.Target + "' 2>/dev/null || " +
+		"tmux select-window -t '" + pane.SessionName + ":" + pane.WindowIndex + "' 2>/dev/null; " +
+		"tmux select-pane -t '" + pane.Target + "' 2>/dev/null; " +
+		"open -b '" + terminalBundleID + "'"
+
+	logging.Debug("Built tmux focus command: %s", cmd)
+	return cmd
+}


### PR DESCRIPTION
## Summary
When running Claude Code inside tmux, clicking a notification now navigates to the exact session/window/pane that triggered it — no more hunting through tmux panes!

## Changes
- **New file:** `internal/notifier/tmux_darwin.go` — tmux pane detection and focus command building
- **Modified:** `notifier.go` — uses `-execute` instead of `-activate` when tmux is detected
- **Modified:** `config.go` — adds `tmuxPaneFocus` option (default: `true`)

## How it works
1. Detects tmux via `$TMUX` env var when notification fires
2. Captures current pane target: `tmux display-message -p '#{session_name}:#{window_index}.#{pane_index}'`
3. Uses `terminal-notifier -execute` to run:
   ```bash
   tmux switch-client -t 'session:0.1' && open -b 'com.apple.Terminal'
   ```

## Config
```json
{
  "notifications": {
    "desktop": {
      "tmuxPaneFocus": true
    }
  }
}
```

Set to `false` to disable and use the original `-activate` behavior.

## Testing
- Build passes: `go build ./...`
- Tested concept with tmux on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена поддержка фокусировки tmux панелей при получении уведомлений на macOS. При включении этой функции клик на уведомление автоматически переводит фокус на соответствующую tmux панель, значительно повышая удобство работы с несколькими активными терминальными сессиями.
  * Добавлена новая опция конфигурации для управления поведением.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->