### PR TITLE
feat: add terminal bell for tab indicators

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type NotificationsConfig struct {
 type DesktopConfig struct {
 	Enabled          bool    `json:"enabled"`
 	Sound            bool    `json:"sound"`
+	TerminalBell     *bool   `json:"terminalBell"`     // Send BEL to /dev/tty for terminal tab indicators (default: true)
 	Volume           float64 `json:"volume"`           // Volume level 0.0-1.0, default 1.0 (full volume)
 	AudioDevice      string  `json:"audioDevice"`      // Audio output device name (empty = system default)
 	AppIcon          string  `json:"appIcon"`          // Path to app icon
@@ -332,6 +333,14 @@ func (c *Config) IsStatusEnabled(status string) bool {
 		return true // nil means enabled (backward compatibility)
 	}
 	return *info.Enabled
+}
+
+// IsTerminalBellEnabled returns true if terminal bell (BEL) should be sent (default: true)
+func (c *Config) IsTerminalBellEnabled() bool {
+	if c.Notifications.Desktop.TerminalBell == nil {
+		return true // Default: enabled
+	}
+	return *c.Notifications.Desktop.TerminalBell
 }
 
 // IsStatusDesktopEnabled returns true if desktop notifications for this status are enabled

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -519,6 +519,22 @@ func TestDefaultConfig_ClickToFocus(t *testing.T) {
 	assert.Empty(t, cfg.Notifications.Desktop.TerminalBundleID, "TerminalBundleID should be empty for auto-detect")
 }
 
+func TestIsTerminalBellEnabled(t *testing.T) {
+	// Default (nil) should be true
+	cfg := DefaultConfig()
+	assert.True(t, cfg.IsTerminalBellEnabled(), "TerminalBell should be true by default (nil)")
+
+	// Explicitly true
+	bellOn := true
+	cfg.Notifications.Desktop.TerminalBell = &bellOn
+	assert.True(t, cfg.IsTerminalBellEnabled(), "TerminalBell should be true when set to true")
+
+	// Explicitly false
+	bellOff := false
+	cfg.Notifications.Desktop.TerminalBell = &bellOff
+	assert.False(t, cfg.IsTerminalBellEnabled(), "TerminalBell should be false when set to false")
+}
+
 func TestLoadConfig_ClickToFocus(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.json")


### PR DESCRIPTION
Write BEL character to /dev/tty when sending desktop notifications to trigger terminal tab indicators (e.g. Ghostty tab highlight, tmux window bell flag). This helps users identify which terminal tab has Claude Code feedback waiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop notifications now also trigger a terminal bell for enhanced auditory feedback before delivering the visual notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->