### PR TITLE
docs: add custom example for ntfy.sh

### DIFF
--- a/docs/webhooks/custom.md
+++ b/docs/webhooks/custom.md
@@ -270,7 +270,7 @@ _push notifications to Android/iOS/browsers/etc., FOSS_
 },
 ```
 
-In the example above templates are used to interpret this plugins's default json, see the docs for more.
+In the example above templates are used to interpret this plugin's default json, see the docs for more.
 You can also use ntfy <ins>as middleware transformer for other webhooks</ins> or relay to channels like email, etc.
 
 ### Zapier


### PR DESCRIPTION
ntfy.sh is the service for delivering push notifications to a range of devices, incl push notifications. Kinda like pushbullet, but much developer-friendlier and FOSS. Also has relay superpowers.

I was going to ask for support of ntfy.sh via preset, because sending default json looks ugly. But reading the docs along the way, I discovered, that this is possible without any plugin's code modifications with ntfy's templates.

I suggest adding this as example. While ntfy on its own might not be a well-known tool, notifications to handheld devices (without cluttering messengers) seem very valuable for this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new ntfy.sh webhook integration guide in Common Integrations. Provides step-by-step setup, a JSON webhook example, guidance on custom headers for message, title, priority and template, and notes on using ntfy as middleware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->