### PR TITLE
fix: remove redundant `sh` prefix from hook commands (Windows Git Bash)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh ${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook PreToolUse",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook PreToolUse",
             "timeout": 30
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh ${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook Notification",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook Notification",
             "timeout": 30
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh ${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook Stop",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook Stop",
             "timeout": 30
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh ${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook SubagentStop",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/hook-wrapper.sh handle-hook SubagentStop",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
Claude Code passes hook command args directly to sh without -c flag, causing the `sh` prefix to be interpreted as a script filename. sh resolves to /usr/bin/sh (binary) → "cannot execute binary file" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized hook execution mechanism for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->