### PR TITLE
feat: add configurable suppressFilters for notification suppression

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     },
     "metadata": {
         "description": "Smart notifications marketplace for Claude Code (Go implementation)",
-        "version": "1.26.5"
+        "version": "1.26.0"
     },
     "plugins": [{
         "name": "claude-notifications-go",
         "source": "./",
         "description": "Smart notifications for Claude Code task statuses (Go implementation)",
-        "version": "1.26.5",
+        "version": "1.26.0",
         "author": {
             "name": "777genius",
             "email": "[email protected]"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "claude-notifications-go",
-    "version": "1.26.5",
+    "version": "1.26.0",
     "description": "Smart notifications for Claude Code task statuses (Go implementation)",
     "author": {
         "name": "777genius",

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Edit the config file directly:
 | `respectJudgeMode` | `true` | Honor `CLAUDE_HOOK_JUDGE_MODE=true` env var to suppress notifications |
 | `suppressQuestionAfterTaskCompleteSeconds` | `12` | Suppress question notifications for N seconds after task complete |
 | `suppressQuestionAfterAnyNotificationSeconds` | `12` | Suppress question notifications for N seconds after any notification |
-| `suppressFilters` | `[ClaudeProbe rule]` | Array of rules to suppress notifications by status, git branch, and/or folder. Each rule is an AND of its fields; omitted fields match any value. Set `gitBranch` to `""` to match sessions outside git repos. Default config ships with a rule suppressing ClaudeProbe remote-control completions. |
+| `suppressFilters` | `[]` | Array of rules to suppress notifications by status, git branch, and/or folder. Each rule is an AND of its fields; omitted fields match any value. Set `gitBranch` to `""` to match sessions outside git repos. |
 
 Each status can be individually disabled by adding `"enabled": false`.
 

--- a/cmd/claude-notifications/main.go
+++ b/cmd/claude-notifications/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/777genius/claude-notifications/internal/notifier"
 )
 
-const version = "1.26.5"
+const version = "1.26.0"
 
 func main() {
 	// Initialize global error handler with panic recovery

--- a/config/config.json
+++ b/config/config.json
@@ -19,14 +19,7 @@
     "suppressQuestionAfterTaskCompleteSeconds": 12,
     "suppressQuestionAfterAnyNotificationSeconds": 0,
     "suppressForSubagents": true,
-    "suppressFilters": [
-      {
-        "name": "Suppress ClaudeProbe completions (remote-control)",
-        "status": "task_complete",
-        "gitBranch": "",
-        "folder": "ClaudeProbe"
-      }
-    ]
+    "suppressFilters": []
   },
   "statuses": {
     "task_complete": {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -189,6 +189,16 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 		return nil
 	}
 
+	// Check suppress-filters before any state mutations (dedup lock, cooldowns)
+	{
+		gitBranch := platform.GetGitBranch(hookData.CWD)
+		folderName := filepath.Base(hookData.CWD)
+		if h.cfg.ShouldFilter(string(status), gitBranch, folderName) {
+			logging.Debug("Notification suppressed by filter: status=%s branch=%q folder=%s", status, gitBranch, folderName)
+			return nil
+		}
+	}
+
 	// Phase 2: Acquire lock before sending (per hook event type)
 	acquired, err := h.dedupMgr.AcquireLock(hookData.SessionID, hookEvent)
 	if err != nil {
@@ -201,16 +211,6 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 
 	logging.Debug("Lock acquired, proceeding with notification")
 	// Note: Lock is NOT released - it ages out naturally after 2s to prevent rapid duplicates
-
-	// Check suppress-filters early — before any state mutations (cooldowns, dedup)
-	{
-		gitBranch := platform.GetGitBranch(hookData.CWD)
-		folderName := filepath.Base(hookData.CWD)
-		if h.cfg.ShouldFilter(string(status), gitBranch, folderName) {
-			logging.Debug("Notification suppressed by filter: status=%s branch=%q folder=%s", status, gitBranch, folderName)
-			return nil
-		}
-	}
 
 	// Check cooldown for question status BEFORE updating notification time
 	if status == analyzer.StatusQuestion {


### PR DESCRIPTION
## Summary
- Add rule-based `suppressFilters` config array that suppresses notifications matching specified conditions (status, git branch, folder name)
- All specified fields in a rule must match (AND logic); omitted fields act as wildcards

- Motivation: since using Claude Code's new `remote-control` feature, I started receiving many notifications similar to the example below. The `suppressFilters` config is now filtering out these unnecessary notifications.
```text
✅ Completed
[quiet 609f40e2 ClaudeProbe] Task completed successfully ⏱ 9s
Session: 609f40e2-7452-41f1-9e7f-206fcae820c3•Today at 12:02
```

## Example config
```json
{
  "notifications": {
    "suppressFilters": [
      {
        "name": "Suppress ClaudeProbe completions (remote-control)",
        "status": "task_complete",
        "gitBranch": "",
        "folder": "ClaudeProbe"
      }
    ]
  }
}
```

## Test plan
- [x] Unit tests for `SuppressFilter.Matches()` — 11 table-driven cases
- [x] Unit tests for `SuppressFilter.HasConditions()`
- [x] Unit tests for `Config.ShouldFilter()` with multiple rules
- [x] Validation tests — rejects empty filters and invalid status values
- [x] JSON load/parse test — end-to-end config deserialization
- [x] Integration tests in hooks — matching filter suppresses, non-matching allows
- [x] `make build`, `make lint`, `make test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suppressFilters configuration option to suppress notifications based on matching status, git branch, and folder conditions.

* **Documentation**
  * Updated configuration documentation with suppressFilters details, including default value and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->