### PR TITLE
Fix: Notification click opens Nautilus instead of terminal/VS Code

### DIFF
--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -45,6 +45,12 @@ func GetAppID(terminalName string) string {
 	}
 }
 
+// GetDesktopEntryID returns the desktop entry ID (without .desktop suffix) for a terminal.
+// This is the value expected by the freedesktop "desktop-entry" notification hint.
+func GetDesktopEntryID(terminalName string) string {
+	return strings.TrimSuffix(GetAppID(terminalName), ".desktop")
+}
+
 // GetWlrctlAppID returns the wlroots app_id for a terminal name.
 func GetWlrctlAppID(terminalName string) string {
 	switch strings.ToLower(terminalName) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -263,6 +263,10 @@ func (s *Server) handleNotification(req *NotifyRequest) (*NotifyResponse, error)
 		Actions: []notify.Action{
 			{Key: "default", Label: "Focus Terminal"},
 		},
+		Hints: map[string]dbus.Variant{
+			"desktop-entry":  dbus.MakeVariant(GetDesktopEntryID(focusTarget)),
+			"suppress-sound": dbus.MakeVariant(true),
+		},
 	}
 
 	// Send notification


### PR DESCRIPTION
# Context

On Ubuntu (GNOME), clicking a notification from claude-notifications-go opens Nautilus (the file manager) instead of focusing the terminal or VS Code. This happens because the D-Bus notification sent by the daemon is missing the desktop-entry hint. GNOME Shell uses this hint to identify which application a notification belongs to. Without it, GNOME falls back to opening Nautilus when the user clicks the notification.

# Root Cause

In internal/daemon/server.go:258-266, the notify.Notification is created without any Hints:
```
n := notify.Notification{                         
    AppName:       "claude-notifications",        
    Summary:       req.Title,                     
    Body:          req.Body,                      
    ExpireTimeout: timeout,                       
    Actions: []notify.Action{                     
        {Key: "default", Label: "Focus Terminal"},
    },                                            
}                                                 
```

The freedesktop notification spec defines a desktop-entry hint that tells the notification server which application the notification belongs to. GNOME Shell uses this to:
1. Group notifications by app                                                                                                                                             
2. Determine which app to activate when clicking the notification in the Message Tray                                                                                     
3. Show the correct app icon                                                                                                                                              
                                                                                                                                                                          
Without this hint, GNOME can't identify the source app and falls back to opening the file manager.                                                                        

# Here's a summary of the changes:

  internal/daemon/mappings.go — Added GetDesktopEntryID() that strips the .desktop suffix from GetAppID(), returning just the desktop entry ID (e.g., code, org.gnome.Terminal).

  internal/daemon/server.go — Added Hints map to the notification with:
  - desktop-entry: Tells GNOME which app owns the notification, so clicking it focuses the correct terminal/VS Code instead of Nautilus
  - suppress-sound: Prevents GNOME from playing a duplicate notification sound on top of the custom one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Linux notification integration with enhanced desktop environment support and refined notification behavior for better system integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->