### PR TITLE
fix: skip content dedup for question status notifications

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -315,13 +315,21 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 		}
 	}()
 
-	// Check for duplicate message content (3 minutes = 180 seconds window)
-	isDuplicate, err := h.stateMgr.IsDuplicateMessage(hookData.SessionID, message, 180)
-	if err != nil {
-		logging.Warn("Failed to check duplicate message: %v", err)
-	} else if isDuplicate {
-		logging.Debug("Duplicate message content detected within 3 minutes, skipping")
-		return nil
+	// Check for duplicate message content (3 minutes = 180 seconds window).
+	// Skip for question status: consecutive permission prompts read the same
+	// transcript and produce identical summaries, but each is a distinct
+	// user-facing event. Question is already protected by per-hook dedup
+	// lock (2s TTL), content lock (5s TTL), and cooldown suppression.
+	if status == analyzer.StatusQuestion {
+		logging.Debug("Skipping content dedup for question status")
+	} else {
+		isDuplicate, err := h.stateMgr.IsDuplicateMessage(hookData.SessionID, message, 180)
+		if err != nil {
+			logging.Warn("Failed to check duplicate message: %v", err)
+		} else if isDuplicate {
+			logging.Debug("Duplicate message content detected within 3 minutes, skipping")
+			return nil
+		}
 	}
 
 	// Update last notification time and message

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -501,6 +501,62 @@ func TestHandler_EarlyDuplicateCheck(t *testing.T) {
 	}
 }
 
+func TestHandler_ConsecutiveNotifications_SkipsContentDedup(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+			SuppressQuestionAfterAnyNotificationSeconds: intPtr(0), // disable cooldown for this test
+			SuppressQuestionAfterTaskCompleteSeconds:    intPtr(0),
+		},
+		Statuses: map[string]config.StatusInfo{
+			"question": {Title: "Question"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+
+	// First Notification hook (permission prompt #1)
+	hookData1 := buildHookDataJSON(HookData{
+		SessionID: "test-consecutive-notif",
+		CWD:       "/test",
+	})
+
+	err := handler.HandleHook("Notification", hookData1)
+	if err != nil {
+		t.Fatalf("first notification error: %v", err)
+	}
+
+	firstCallCount := mockNotif.callCount()
+	if firstCallCount == 0 {
+		t.Fatal("first notification should be sent")
+	}
+
+	// Wait for per-hook dedup lock to expire (2s TTL) so the second
+	// notification is not blocked by the early duplicate check.
+	// It should still be within the 180s content dedup window.
+	time.Sleep(2100 * time.Millisecond)
+
+	// Second Notification hook with same session (permission prompt #2).
+	// This generates identical summary because the transcript hasn't changed.
+	hookData2 := buildHookDataJSON(HookData{
+		SessionID: "test-consecutive-notif",
+		CWD:       "/test",
+	})
+
+	err = handler.HandleHook("Notification", hookData2)
+	if err != nil {
+		t.Fatalf("second notification error: %v", err)
+	}
+
+	// Second notification must NOT be suppressed by content dedup.
+	// Question status skips content dedup because consecutive permission
+	// prompts are distinct user-facing events with identical summaries.
+	if mockNotif.callCount() <= firstCallCount {
+		t.Errorf("second question notification should not be suppressed by content dedup, got %d calls, want > %d",
+			mockNotif.callCount(), firstCallCount)
+	}
+}
+
 // === Cooldown Tests ===
 
 func TestHandler_QuestionCooldownAfterTaskComplete(t *testing.T) {


### PR DESCRIPTION
## Summary

- Skip the 180-second content dedup window for question status notifications
- Add test verifying consecutive notification delivery

## Motivation

When Claude Code triggers multiple sequential permission prompts (e.g. two Bash calls requiring user approval), only the first notification is delivered. The user does not hear subsequent prompts and may not realize the agent is waiting for input.

Even when Claude sends parallel tool calls, the permission UI presents them one at a time. After confirming tool A and waiting for it to execute, the user may leave. When tool B then needs approval, the notification is silently suppressed by the content dedup window because both prompts produce identical summaries from the same transcript.

## Changes

- hooks.go: wrap the content dedup check in a condition that skips StatusQuestion. Question status is already protected by per-hook dedup lock (2s TTL), content lock (5s TTL), and cooldown suppression
- hooks_test.go: add TestHandler_ConsecutiveNotifications_SkipsContentDedup verifying the second notification is not suppressed

## Testing

- go test ./... passes (21 packages)
- Manual: trigger two consecutive permission prompts within 3 minutes, verify both produce notifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Question notifications are no longer suppressed when duplicate content is detected, ensuring users receive all permission-prompt notifications regardless of recent history.

* **Tests**
  * Added test coverage validating consecutive question notifications are properly delivered when content is identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->