### PR TITLE
fix: diagnose disabled Windows toast notifications on failure

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -352,6 +352,10 @@ func (n *Notifier) sendWithBeeep(title, message, appIcon, sound string) error {
 
 	// Send notification using beeep with proper title and clean message
 	if err := beeep.Notify(title, message, appIcon); err != nil {
+		if platform.IsWindows() && !platform.IsToastEnabled(beeep.AppName) {
+			logging.Warn("Toast notifications may be disabled for %q. "+
+				"Check Settings > System > Notifications.", beeep.AppName)
+		}
 		logging.Error("beeep.Notify failed on %s: %v (AppName=%q, title=%q)", runtime.GOOS, err, beeep.AppName, title)
 		return err
 	}

--- a/internal/platform/toast_other.go
+++ b/internal/platform/toast_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package platform
+
+// IsToastEnabled always returns true on non-Windows platforms.
+func IsToastEnabled(appName string) bool {
+	return true
+}

--- a/internal/platform/toast_test.go
+++ b/internal/platform/toast_test.go
@@ -1,0 +1,20 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsToastEnabled_NonExistentApp(t *testing.T) {
+	// An app that has never been registered should return true (default enabled).
+	result := IsToastEnabled("NonExistentTestApp_12345_ShouldNotExist")
+	assert.True(t, result, "IsToastEnabled should return true for unknown apps (default enabled)")
+}
+
+func TestIsToastEnabled_EmptyAppName(t *testing.T) {
+	// Empty app name: Windows won't match any registry key → default enabled
+	// Non-Windows stub always returns true
+	result := IsToastEnabled("")
+	assert.True(t, result, "IsToastEnabled with empty name should return true")
+}

--- a/internal/platform/toast_windows.go
+++ b/internal/platform/toast_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package platform
+
+import "golang.org/x/sys/windows/registry"
+
+const toastSettingsBase = `SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings`
+
+// IsToastEnabled checks if toast notifications are enabled for the given app
+// in Windows Settings. Returns true if enabled or if the registry key does
+// not exist (notifications are enabled by default).
+func IsToastEnabled(appName string) bool {
+	key, err := registry.OpenKey(registry.CURRENT_USER,
+		toastSettingsBase+`\`+appName, registry.QUERY_VALUE)
+	if err != nil {
+		return true // key not found = default enabled
+	}
+	defer key.Close()
+
+	val, _, err := key.GetIntegerValue("Enabled")
+	if err != nil {
+		return true // value not found = default enabled
+	}
+
+	return val != 0
+}


### PR DESCRIPTION
## Summary

- Add Windows Registry check to diagnose disabled toast notifications
- Log actionable warning when toast is disabled in Windows Settings

## Motivation

When a user (or IT policy) disables toast notifications for the app in Windows Settings > System > Notifications, beeep.Notify fails silently with no actionable error message. The user has no way to know why notifications stopped working from the debug log alone.

## Changes

- platform/toast_windows.go (new): read HKCU registry key to check if toast notifications are enabled for the given app name. Returns true (default enabled) when the key does not exist
- platform/toast_other.go (new): stub returning true on non-Windows platforms
- platform/toast_test.go (new): verify safe default behavior (unknown app returns true)
- notifier/notifier.go: after beeep.Notify failure, check IsToastEnabled and log a warning with remediation steps if toast is disabled

Uses diagnostic mode (check after failure) rather than gating mode (check before attempt) to avoid false positives from potential AUMID mismatch.

## Testing

- go test ./... passes (21 packages)
- Manual on Windows: disable toast for the app in Settings, trigger a notification, verify the warning appears in debug log


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware notification checks: on Windows the app reports when toast notifications are disabled and shows a helpful warning; on other platforms notifications are treated as enabled.

* **Bug Fixes**
  * Improved handling and messaging when sending desktop notifications fails on Windows.

* **Tests**
  * Added unit tests covering notification status detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->