### PR TITLE
Fix iTerm2 exact click-to-focus targeting

### DIFF
--- a/internal/notifier/iterm2_focus.go
+++ b/internal/notifier/iterm2_focus.go
@@ -25,6 +25,7 @@ var sendQuickNotification = SendQuickNotification
 var (
 	iTerm2HealthcheckSuccessTTL = 10 * time.Minute
 	iTerm2PythonAPIPromptTTL    = 24 * time.Hour
+	iTerm2PythonAPIHealthcheck  = checkIterm2PythonAPIHealth
 )
 
 type iTerm2HelperHealth int
@@ -44,7 +45,7 @@ func buildIterm2FocusScript(cwd string) string {
 	sessionID := os.Getenv(iTerm2SessionIDEnv)
 	pythonPath, scriptPath, ok := getiTerm2PythonEnv()
 	if ok && (sessionID != "" || isUsableFocusCWD(cwd)) &&
-		checkIterm2PythonAPIHealth(pythonPath, scriptPath) == iTerm2HelperReady {
+		iTerm2PythonAPIHealthcheck(pythonPath, scriptPath) == iTerm2HelperReady {
 		helperCmd := fmt.Sprintf("%s %s",
 			shellQuote(pythonPath),
 			shellQuote(scriptPath),

--- a/internal/notifier/iterm2_focus.go
+++ b/internal/notifier/iterm2_focus.go
@@ -1,0 +1,57 @@
+package notifier
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const iTerm2SessionIDEnv = "ITERM_SESSION_ID"
+
+// buildIterm2FocusScript prefers iTerm2's exact session reveal URL when the
+// current shell exported ITERM_SESSION_ID. This targets the precise tab/pane
+// via the iTerm2 Python API helper. If the helper is unavailable or the exact
+// session can no longer be resolved, it falls back to the generic focus-window
+// path when cwd is available.
+func buildIterm2FocusScript(cwd string) string {
+	sessionID := os.Getenv(iTerm2SessionIDEnv)
+	pythonPath, scriptPath, ok := getiTerm2PythonEnv()
+	if ok && (sessionID != "" || isUsableFocusCWD(cwd)) {
+		helperCmd := fmt.Sprintf("%s %s",
+			shellQuote(pythonPath),
+			shellQuote(scriptPath),
+		)
+		if sessionID != "" {
+			helperCmd += " --termid " + shellQuote(sessionID)
+		}
+		if isUsableFocusCWD(cwd) {
+			helperCmd += " --cwd " + shellQuote(cwd)
+		}
+
+		if !isUsableFocusCWD(cwd) {
+			return helperCmd
+		}
+
+		fallbackCmd := buildBinaryFocusScript(iTerm2BundleID, cwd)
+		if fallbackCmd == "" {
+			return helperCmd
+		}
+
+		// If the exact session helper fails, preserve the previous window-level
+		// fallback instead of leaving the click action as a no-op.
+		return fmt.Sprintf("%s >/dev/null 2>&1 || %s", helperCmd, fallbackCmd)
+	}
+
+	if !isUsableFocusCWD(cwd) {
+		return ""
+	}
+	return buildBinaryFocusScript(iTerm2BundleID, cwd)
+}
+
+func isUsableFocusCWD(cwd string) bool {
+	if cwd == "" {
+		return false
+	}
+	folderName := filepath.Base(cwd)
+	return folderName != "" && folderName != "." && folderName != string(filepath.Separator)
+}

--- a/internal/notifier/iterm2_focus.go
+++ b/internal/notifier/iterm2_focus.go
@@ -1,12 +1,39 @@
 package notifier
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
+
+	"github.com/777genius/claude-notifications/internal/config"
+	"github.com/777genius/claude-notifications/internal/logging"
 )
 
 const iTerm2SessionIDEnv = "ITERM_SESSION_ID"
+
+const (
+	iTerm2HealthcheckFlag           = "--healthcheck"
+	iTerm2HealthcheckExitDisabled   = 11
+	iTerm2HealthcheckExitModuleMiss = 12
+	iTerm2HealthcheckExitOther      = 13
+)
+
+var sendQuickNotification = SendQuickNotification
+
+var (
+	iTerm2HealthcheckSuccessTTL = 10 * time.Minute
+	iTerm2PythonAPIPromptTTL    = 24 * time.Hour
+)
+
+type iTerm2HelperHealth int
+
+const (
+	iTerm2HelperUnavailable iTerm2HelperHealth = iota
+	iTerm2HelperReady
+	iTerm2HelperDisabled
+)
 
 // buildIterm2FocusScript prefers iTerm2's exact session reveal URL when the
 // current shell exported ITERM_SESSION_ID. This targets the precise tab/pane
@@ -16,7 +43,8 @@ const iTerm2SessionIDEnv = "ITERM_SESSION_ID"
 func buildIterm2FocusScript(cwd string) string {
 	sessionID := os.Getenv(iTerm2SessionIDEnv)
 	pythonPath, scriptPath, ok := getiTerm2PythonEnv()
-	if ok && (sessionID != "" || isUsableFocusCWD(cwd)) {
+	if ok && (sessionID != "" || isUsableFocusCWD(cwd)) &&
+		checkIterm2PythonAPIHealth(pythonPath, scriptPath) == iTerm2HelperReady {
 		helperCmd := fmt.Sprintf("%s %s",
 			shellQuote(pythonPath),
 			shellQuote(scriptPath),
@@ -48,10 +76,107 @@ func buildIterm2FocusScript(cwd string) string {
 	return buildBinaryFocusScript(iTerm2BundleID, cwd)
 }
 
+func checkIterm2PythonAPIHealth(pythonPath, scriptPath string) iTerm2HelperHealth {
+	if isRecentMarker(iTerm2HealthcheckSuccessMarkerPath(), iTerm2HealthcheckSuccessTTL) {
+		return iTerm2HelperReady
+	}
+
+	cmd := execCommand(pythonPath, scriptPath, iTerm2HealthcheckFlag)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		touchMarker(iTerm2HealthcheckSuccessMarkerPath())
+		return iTerm2HelperReady
+	}
+
+	_ = os.Remove(iTerm2HealthcheckSuccessMarkerPath())
+
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == iTerm2HealthcheckExitDisabled {
+		logging.Warn("iTerm2 Python API is disabled: %s", stringsTrimSpace(string(output)))
+		promptIterm2PythonAPIDisabled()
+		return iTerm2HelperDisabled
+	}
+
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == iTerm2HealthcheckExitModuleMiss {
+		logging.Warn("iTerm2 Python helper module missing: %s", stringsTrimSpace(string(output)))
+		return iTerm2HelperUnavailable
+	}
+
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == iTerm2HealthcheckExitOther {
+		logging.Warn("iTerm2 Python helper healthcheck failed: %s", stringsTrimSpace(string(output)))
+		return iTerm2HelperUnavailable
+	}
+
+	logging.Warn("iTerm2 Python helper healthcheck failed: %v output=%s", err, stringsTrimSpace(string(output)))
+	return iTerm2HelperUnavailable
+}
+
 func isUsableFocusCWD(cwd string) bool {
 	if cwd == "" {
 		return false
 	}
 	folderName := filepath.Base(cwd)
 	return folderName != "" && folderName != "." && folderName != string(filepath.Separator)
+}
+
+func iTerm2HealthcheckSuccessMarkerPath() string {
+	stableDir, err := config.GetStableConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(stableDir, ".iterm2-python-api-ok")
+}
+
+func iTerm2PythonAPIPromptMarkerPath() string {
+	stableDir, err := config.GetStableConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(stableDir, ".iterm2-python-api-disabled-prompted")
+}
+
+func isRecentMarker(path string, ttl time.Duration) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) < ttl
+}
+
+func touchMarker(path string) {
+	if path == "" {
+		return
+	}
+	dir := filepath.Dir(path)
+	_ = os.MkdirAll(dir, 0o755)
+	_ = os.WriteFile(path, []byte("1"), 0o644)
+}
+
+func promptIterm2PythonAPIDisabled() {
+	markerPath := iTerm2PythonAPIPromptMarkerPath()
+	if isRecentMarker(markerPath, iTerm2PythonAPIPromptTTL) {
+		return
+	}
+
+	touchMarker(markerPath)
+	_ = sendQuickNotification(
+		"iTerm2 Python API Disabled",
+		"Enable it in iTerm2 > Settings > General > Magic to make notification clicks open the exact tab or pane.",
+		`open -a iTerm`,
+	)
+}
+
+func stringsTrimSpace(s string) string {
+	start := 0
+	for start < len(s) && (s[start] == ' ' || s[start] == '\n' || s[start] == '\t' || s[start] == '\r') {
+		start++
+	}
+	end := len(s)
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\n' || s[end-1] == '\t' || s[end-1] == '\r') {
+		end--
+	}
+	return s[start:end]
 }

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -308,12 +308,8 @@ func buildTerminalNotifierArgs(title, message, bundleID, cwd string, clickToFocu
 	if clickToFocus {
 		// Note: -sender option removed because it conflicts with -activate on macOS Sequoia (15.x)
 		// Using -sender causes click-to-focus to stop working.
-		if cwd != "" {
-			if script := buildFocusScript(bundleID, cwd); script != "" {
-				args = append(args, "-execute", script)
-			} else {
-				args = append(args, "-activate", bundleID)
-			}
+		if script := buildFocusScript(bundleID, cwd); script != "" {
+			args = append(args, "-execute", script)
 		} else {
 			args = append(args, "-activate", bundleID)
 		}
@@ -333,12 +329,19 @@ func buildTerminalNotifierArgs(title, message, bundleID, cwd string, clickToFocu
 // raise the correct window across Spaces.
 // Returns "" when cwd is empty or unusable (caller should use -activate instead).
 func buildFocusScript(bundleID, cwd string) string {
-	if cwd == "" {
-		return ""
+	if isIterm2BundleID(bundleID) {
+		return buildIterm2FocusScript(cwd)
 	}
 
 	if isGhosttyBundleID(bundleID) {
+		if cwd == "" {
+			return ""
+		}
 		return buildGhosttyFocusScript(bundleID, cwd)
+	}
+
+	if cwd == "" {
+		return ""
 	}
 
 	folderName := filepath.Base(cwd)

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1354,6 +1354,56 @@ func TestBuildFocusScript_Iterm2WithoutHelperFallsBackToFocusWindow(t *testing.T
 	}
 }
 
+func TestBuildFocusScript_Iterm2DisabledAPIFallsBackAndPromptsOnce(t *testing.T) {
+	setupFakeiTerm2Env(t)
+	t.Setenv(iTerm2SessionIDEnv, "w0t0p9:disabled")
+
+	restoreExecCommand := installFakeOpen(t, "", iTerm2HealthcheckExitDisabled)
+	defer restoreExecCommand()
+
+	originalSendQuickNotification := sendQuickNotification
+	defer func() {
+		sendQuickNotification = originalSendQuickNotification
+	}()
+
+	promptCount := 0
+	sendQuickNotification = func(title, message, executeCmd string) error {
+		promptCount++
+		return nil
+	}
+
+	script := buildFocusScript("com.googlecode.iterm2", "/home/user/my-project")
+	if !strings.Contains(script, "focus-window") {
+		t.Fatalf("disabled iTerm2 API should fall back to focus-window, got: %s", script)
+	}
+	if strings.Contains(script, "iterm2-select-tab.py") {
+		t.Fatalf("disabled iTerm2 API should not keep helper in execute script, got: %s", script)
+	}
+	if promptCount != 1 {
+		t.Fatalf("expected one prompt on first disabled-api detection, got %d", promptCount)
+	}
+
+	script = buildFocusScript("com.googlecode.iterm2", "/home/user/my-project")
+	if !strings.Contains(script, "focus-window") {
+		t.Fatalf("disabled iTerm2 API should still fall back to focus-window, got: %s", script)
+	}
+	if promptCount != 1 {
+		t.Fatalf("disabled-api prompt should be throttled, got %d prompts", promptCount)
+	}
+}
+
+func TestBuildTmuxCCNotifierArgs_DisabledAPIErrors(t *testing.T) {
+	setupFakeiTerm2Env(t)
+
+	restoreExecCommand := installFakeOpen(t, "", iTerm2HealthcheckExitDisabled)
+	defer restoreExecCommand()
+
+	_, err := buildTmuxCCNotifierArgs("Title", "Msg", "%42", iTerm2BundleID)
+	if err == nil {
+		t.Fatal("expected error when iTerm2 Python API is disabled")
+	}
+}
+
 func TestBuildTerminalNotifierArgs_WithCWD_UsesExecute(t *testing.T) {
 	args := buildTerminalNotifierArgs("Title", "Message", "com.microsoft.VSCode", "/home/user/proj", true)
 	if containsArg(args, "-activate", "com.microsoft.VSCode") {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1302,6 +1302,7 @@ func TestBuildFocusScript_RegularTerminal_UsesFocusWindow(t *testing.T) {
 
 func TestBuildFocusScript_Iterm2PrefersExactSessionHelper(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 	t.Setenv(iTerm2SessionIDEnv, "w0t0p0:abc-123")
 
 	script := buildFocusScript("com.googlecode.iterm2", "/home/user/my-project")
@@ -1325,6 +1326,7 @@ func TestBuildFocusScript_Iterm2PrefersExactSessionHelper(t *testing.T) {
 
 func TestBuildFocusScript_Iterm2WithoutCWDStillTargetsSession(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 	t.Setenv(iTerm2SessionIDEnv, "w0t0p1:xyz")
 
 	script := buildFocusScript("com.googlecode.iterm2", "")
@@ -1436,6 +1438,7 @@ func TestBuildTerminalNotifierArgs_WithCWD_TerminalUsesFocusWindow(t *testing.T)
 
 func TestBuildTerminalNotifierArgs_Iterm2SessionIDUsesExecuteWithoutCWD(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 	t.Setenv(iTerm2SessionIDEnv, "w0t0p7:test")
 
 	args := buildTerminalNotifierArgs("Title", "Message", "com.googlecode.iterm2", "", true)

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1190,6 +1190,7 @@ func TestSendDesktop_SubtitleBranchOnly(t *testing.T) {
 // === Tests for buildFocusScript and helpers ===
 
 func TestBuildFocusScript_EmptyCWD(t *testing.T) {
+	t.Setenv(iTerm2SessionIDEnv, "")
 	script := buildFocusScript("com.microsoft.VSCode", "")
 	if script != "" {
 		t.Errorf("buildFocusScript with empty cwd should return empty, got: %s", script)
@@ -1281,6 +1282,7 @@ func TestCwdToFileURL(t *testing.T) {
 }
 
 func TestBuildFocusScript_RegularTerminal_UsesFocusWindow(t *testing.T) {
+	t.Setenv(iTerm2SessionIDEnv, "")
 	script := buildFocusScript("com.googlecode.iterm2", "/home/user/my-project")
 	// Regular terminals now use focus-window subcommand instead of AppleScript.
 	// This avoids the Automation permission issue on macOS Tahoe (26.x).
@@ -1298,6 +1300,60 @@ func TestBuildFocusScript_RegularTerminal_UsesFocusWindow(t *testing.T) {
 	}
 }
 
+func TestBuildFocusScript_Iterm2PrefersExactSessionHelper(t *testing.T) {
+	setupFakeiTerm2Env(t)
+	t.Setenv(iTerm2SessionIDEnv, "w0t0p0:abc-123")
+
+	script := buildFocusScript("com.googlecode.iterm2", "/home/user/my-project")
+
+	if !strings.Contains(script, "iterm2-select-tab.py") {
+		t.Fatalf("iTerm2 script should use the Python helper, got: %s", script)
+	}
+	if !strings.Contains(script, "--termid 'w0t0p0:abc-123'") {
+		t.Errorf("iTerm2 helper should receive the exact termid, got: %s", script)
+	}
+	if !strings.Contains(script, "--cwd '/home/user/my-project'") {
+		t.Errorf("iTerm2 helper should receive cwd fallback, got: %s", script)
+	}
+	if !strings.Contains(script, "||") {
+		t.Errorf("iTerm2 reveal script should preserve fallback, got: %s", script)
+	}
+	if !strings.Contains(script, "focus-window") {
+		t.Errorf("iTerm2 reveal script should fall back to focus-window, got: %s", script)
+	}
+}
+
+func TestBuildFocusScript_Iterm2WithoutCWDStillTargetsSession(t *testing.T) {
+	setupFakeiTerm2Env(t)
+	t.Setenv(iTerm2SessionIDEnv, "w0t0p1:xyz")
+
+	script := buildFocusScript("com.googlecode.iterm2", "")
+
+	if !strings.Contains(script, "iterm2-select-tab.py") {
+		t.Fatalf("iTerm2 script should use the Python helper, got: %s", script)
+	}
+	if !strings.Contains(script, "--termid 'w0t0p1:xyz'") {
+		t.Errorf("iTerm2 helper should receive the exact termid, got: %s", script)
+	}
+	if strings.Contains(script, "focus-window") {
+		t.Errorf("iTerm2 script without cwd should not add focus-window fallback, got: %s", script)
+	}
+}
+
+func TestBuildFocusScript_Iterm2WithoutHelperFallsBackToFocusWindow(t *testing.T) {
+	withIsolatedEnv(t)
+	t.Setenv(iTerm2SessionIDEnv, "w0t0p9:no-helper")
+
+	script := buildFocusScript("com.googlecode.iterm2", "/home/user/my-project")
+
+	if !strings.Contains(script, "focus-window") {
+		t.Fatalf("iTerm2 should fall back to focus-window when helper is unavailable, got: %s", script)
+	}
+	if strings.Contains(script, "iterm2-select-tab.py") {
+		t.Errorf("iTerm2 should not reference helper when it is unavailable, got: %s", script)
+	}
+}
+
 func TestBuildTerminalNotifierArgs_WithCWD_UsesExecute(t *testing.T) {
 	args := buildTerminalNotifierArgs("Title", "Message", "com.microsoft.VSCode", "/home/user/proj", true)
 	if containsArg(args, "-activate", "com.microsoft.VSCode") {
@@ -1310,6 +1366,7 @@ func TestBuildTerminalNotifierArgs_WithCWD_UsesExecute(t *testing.T) {
 }
 
 func TestBuildTerminalNotifierArgs_WithCWD_TerminalUsesFocusWindow(t *testing.T) {
+	t.Setenv(iTerm2SessionIDEnv, "")
 	args := buildTerminalNotifierArgs("Title", "Message", "com.googlecode.iterm2", "/home/user/my-project", true)
 	execVal := getArgValue(args, "-execute")
 	if execVal == "" {
@@ -1324,6 +1381,24 @@ func TestBuildTerminalNotifierArgs_WithCWD_TerminalUsesFocusWindow(t *testing.T)
 	}
 	if !strings.Contains(execVal, "my-project") {
 		t.Errorf("-execute value should contain cwd path, got: %s", execVal)
+	}
+}
+
+func TestBuildTerminalNotifierArgs_Iterm2SessionIDUsesExecuteWithoutCWD(t *testing.T) {
+	setupFakeiTerm2Env(t)
+	t.Setenv(iTerm2SessionIDEnv, "w0t0p7:test")
+
+	args := buildTerminalNotifierArgs("Title", "Message", "com.googlecode.iterm2", "", true)
+
+	if containsArg(args, "-activate", "com.googlecode.iterm2") {
+		t.Error("iTerm2 exact session targeting should prefer -execute over -activate")
+	}
+	execVal := getArgValue(args, "-execute")
+	if !strings.Contains(execVal, "iterm2-select-tab.py") {
+		t.Errorf("-execute should contain iTerm2 helper, got: %s", execVal)
+	}
+	if !strings.Contains(execVal, "--termid 'w0t0p7:test'") {
+		t.Errorf("-execute should pass termid to helper, got: %s", execVal)
 	}
 }
 
@@ -1350,6 +1425,7 @@ func TestSendQuickNotification_EmptyFields(t *testing.T) {
 }
 
 func TestBuildFocusScript_RegularTerminal_InvalidCWD_FallbackToActivate(t *testing.T) {
+	t.Setenv(iTerm2SessionIDEnv, "")
 	// When cwd is "." (invalid), buildFocusScript returns "" and
 	// buildTerminalNotifierArgs falls back to -activate (app-level focus)
 	args := buildTerminalNotifierArgs("Title", "Msg", "com.googlecode.iterm2", ".", true)

--- a/internal/notifier/tmux_iterm2.go
+++ b/internal/notifier/tmux_iterm2.go
@@ -49,7 +49,7 @@ func buildIterm2TmuxNotifierArgs(title, message, paneTarget, bundleID string) ([
 	if !ok {
 		return nil, fmt.Errorf("iterm2 venv or helper script not found")
 	}
-	if checkIterm2PythonAPIHealth(pythonPath, scriptPath) != iTerm2HelperReady {
+	if iTerm2PythonAPIHealthcheck(pythonPath, scriptPath) != iTerm2HelperReady {
 		return nil, fmt.Errorf("iterm2 python api unavailable")
 	}
 

--- a/internal/notifier/tmux_iterm2.go
+++ b/internal/notifier/tmux_iterm2.go
@@ -49,6 +49,9 @@ func buildIterm2TmuxNotifierArgs(title, message, paneTarget, bundleID string) ([
 	if !ok {
 		return nil, fmt.Errorf("iterm2 venv or helper script not found")
 	}
+	if checkIterm2PythonAPIHealth(pythonPath, scriptPath) != iTerm2HelperReady {
+		return nil, fmt.Errorf("iterm2 python api unavailable")
+	}
 
 	tmuxPath := getTmuxPath()
 	socketPath := getTmuxSocketPath()

--- a/internal/notifier/tmux_iterm2_test.go
+++ b/internal/notifier/tmux_iterm2_test.go
@@ -90,6 +90,17 @@ func withIsolatedEnv(t *testing.T) {
 	})
 }
 
+func overrideIterm2Healthcheck(t *testing.T, health iTerm2HelperHealth) {
+	t.Helper()
+	original := iTerm2PythonAPIHealthcheck
+	iTerm2PythonAPIHealthcheck = func(string, string) iTerm2HelperHealth {
+		return health
+	}
+	t.Cleanup(func() {
+		iTerm2PythonAPIHealthcheck = original
+	})
+}
+
 func TestGetiTerm2PythonEnv_NoVenv(t *testing.T) {
 	withIsolatedEnv(t)
 	_, _, ok := getiTerm2PythonEnv()
@@ -108,6 +119,7 @@ func TestBuildTmuxCCNotifierArgs_NoVenv(t *testing.T) {
 
 func TestBuildTmuxCCNotifierArgs_StripsPanePrefix(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 
 	args, err := buildTmuxCCNotifierArgs("Title", "Msg", "%42", "com.test")
 	if err != nil {
@@ -122,6 +134,7 @@ func TestBuildTmuxCCNotifierArgs_StripsPanePrefix(t *testing.T) {
 
 func TestBuildTmuxCCNotifierArgs_ContainsActivate(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 
 	args, err := buildTmuxCCNotifierArgs("Title", "Msg", "%42", "com.googlecode.iterm2")
 	if err != nil {
@@ -142,6 +155,7 @@ func TestBuildTmuxCCNotifierArgs_ContainsActivate(t *testing.T) {
 
 func TestBuildTmuxCCNotifierArgs_HasGroup(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 
 	args, err := buildTmuxCCNotifierArgs("Title", "Msg", "%10", "com.test")
 	if err != nil {
@@ -159,6 +173,7 @@ func TestBuildTmuxCCNotifierArgs_HasGroup(t *testing.T) {
 
 func TestBuildTmuxCCNotifierArgs_PaneWithoutPercent(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 
 	args, err := buildTmuxCCNotifierArgs("Title", "Msg", "42", "com.test")
 	if err != nil {
@@ -173,6 +188,7 @@ func TestBuildTmuxCCNotifierArgs_PaneWithoutPercent(t *testing.T) {
 
 func TestBuildTmuxCCNotifierArgs_EmptyPaneTarget(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 
 	args, err := buildTmuxCCNotifierArgs("Title", "Msg", "", "com.test")
 	if err != nil {
@@ -188,6 +204,7 @@ func TestBuildTmuxCCNotifierArgs_EmptyPaneTarget(t *testing.T) {
 
 func TestBuildTmuxClickArgs_Iterm2PlainTmuxUsesHelper(t *testing.T) {
 	setupFakeiTerm2Env(t)
+	overrideIterm2Healthcheck(t, iTerm2HelperReady)
 
 	oldTmux := os.Getenv("TMUX")
 	oldPane := os.Getenv("TMUX_PANE")

--- a/scripts/iterm2-select-tab.py
+++ b/scripts/iterm2-select-tab.py
@@ -13,11 +13,15 @@ import argparse
 import subprocess
 import sys
 
+EXIT_PYTHON_API_DISABLED = 11
+EXIT_MODULE_MISSING = 12
+EXIT_OTHER = 13
+
 try:
     import iterm2
 except ImportError:
     print("iterm2 module not installed. Run: pip install iterm2", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(EXIT_MODULE_MISSING)
 
 
 def parse_args():
@@ -47,8 +51,13 @@ def parse_args():
         action="store_true",
         help="list iTerm2 tabs with tmuxWindowPane and tty variables",
     )
+    parser.add_argument(
+        "--healthcheck",
+        action="store_true",
+        help="check that the iTerm2 Python API is reachable",
+    )
     args = parser.parse_args()
-    if not args.list and not args.pane and not args.termid and not args.cwd:
+    if not args.list and not args.healthcheck and not args.pane and not args.termid and not args.cwd:
         parser.error("--pane, --termid, or --cwd is required unless --list is used")
     return args
 
@@ -215,6 +224,10 @@ async def list_tabs(connection):
 async def main(connection):
     args = parse_args()
 
+    if args.healthcheck:
+        await iterm2.async_get_app(connection)
+        return
+
     if args.list:
         await list_tabs(connection)
         return
@@ -241,4 +254,7 @@ if __name__ == "__main__":
             "iTerm2 > Settings > General > Magic",
             file=sys.stderr,
         )
-        sys.exit(1)
+        message = str(e)
+        if "not enabled" in message.lower() or "problem connecting to iterm2" in message.lower():
+            sys.exit(EXIT_PYTHON_API_DISABLED)
+        sys.exit(EXIT_OTHER)

--- a/scripts/iterm2-select-tab.py
+++ b/scripts/iterm2-select-tab.py
@@ -24,6 +24,15 @@ def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pane", help="tmux pane ID, for example %%42")
     parser.add_argument(
+        "--termid",
+        help="exact iTerm2 session termid (matches $ITERM_SESSION_ID)",
+    )
+    parser.add_argument(
+        "--cwd",
+        default="",
+        help="fallback working directory for unique-session matching",
+    )
+    parser.add_argument(
         "--tmux-path",
         default="tmux",
         help="absolute path to tmux binary",
@@ -39,8 +48,8 @@ def parse_args():
         help="list iTerm2 tabs with tmuxWindowPane and tty variables",
     )
     args = parser.parse_args()
-    if not args.list and not args.pane:
-        parser.error("--pane is required unless --list is used")
+    if not args.list and not args.pane and not args.termid and not args.cwd:
+        parser.error("--pane, --termid, or --cwd is required unless --list is used")
     return args
 
 
@@ -154,6 +163,41 @@ async def select_tab(connection, target_pane, tmux_path, socket_path):
     return False
 
 
+async def select_session(connection, target_termid, target_cwd):
+    """Find and activate an iTerm2 session directly.
+
+    Strategy:
+    1. Exact termid match (ITERM_SESSION_ID) for precise tab/pane targeting
+    2. Unique cwd match as a safe fallback
+    """
+    app = await iterm2.async_get_app(connection)
+    cwd_matches = []
+
+    for window in app.windows:
+        for tab in window.tabs:
+            for session in tab.sessions:
+                termid = await session.async_get_variable("termid")
+                if target_termid and termid == target_termid:
+                    await session.async_activate()
+                    return True
+
+                path = await session.async_get_variable("path")
+                if target_cwd and path == target_cwd:
+                    cwd_matches.append(session)
+
+    if not target_cwd:
+        return False
+
+    if len(cwd_matches) == 1:
+        await cwd_matches[0].async_activate()
+        return True
+
+    if len(cwd_matches) > 1:
+        raise RuntimeError(f"multiple iTerm2 sessions match cwd {target_cwd}")
+
+    return False
+
+
 async def list_tabs(connection):
     """List all iTerm2 tabs with their tmuxWindowPane and tty mappings."""
     app = await iterm2.async_get_app(connection)
@@ -163,7 +207,9 @@ async def list_tabs(connection):
             for session in tab.sessions:
                 wp = await session.async_get_variable("tmuxWindowPane")
                 tty = await session.async_get_variable("tty")
-                print(f"  Tab {i}: tmuxWindowPane={wp} tty={tty}")
+                termid = await session.async_get_variable("termid")
+                path = await session.async_get_variable("path")
+                print(f"  Tab {i}: tmuxWindowPane={wp} tty={tty} termid={termid} path={path}")
 
 
 async def main(connection):
@@ -173,8 +219,15 @@ async def main(connection):
         await list_tabs(connection)
         return
 
-    if not await select_tab(connection, args.pane, args.tmux_path, args.socket):
-        print(f"No tab found for tmux pane {args.pane}", file=sys.stderr)
+    if args.pane:
+        if not await select_tab(connection, args.pane, args.tmux_path, args.socket):
+            print(f"No tab found for tmux pane {args.pane}", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    if not await select_session(connection, args.termid, args.cwd):
+        detail = args.termid or args.cwd
+        print(f"No iTerm2 session found for {detail}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary
- target exact iTerm2 sessions/tabs for plain click-to-focus using the existing Python helper
- add a healthcheck for the iTerm2 Python API and show a throttled notification when it is disabled
- keep safe fallbacks and preserve Windows/macOS/Linux CI coverage

## Verification
- go test ./...
- python3 -m py_compile scripts/iterm2-select-tab.py
- live iTerm2 e2e for exact tab and split-pane targeting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iTerm2 notifications can target exact tabs/panes when the iTerm2 Python API is available.
  * Built-in health checks with a throttled user prompt when the iTerm2 Python API is disabled.

* **Bug Fixes / Behavior**
  * More reliable fallback behavior so clicks still focus a terminal when advanced helpers are unavailable; fixes cases with empty or set working directories.

* **Tests**
  * Expanded test coverage for iTerm2 health, focus-script generation, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->