### PR TITLE
fix: restore minimized macos windows before focusing

### DIFF
--- a/internal/notifier/ax_focus_darwin.go
+++ b/internal/notifier/ax_focus_darwin.go
@@ -120,10 +120,33 @@ static int requestScreenRecordingAccess(void) {
 	return CGRequestScreenCaptureAccess() ? 1 : 0;
 }
 
+// restoreAndRaiseWindow restores a minimized window before raising it.
+// Returns 2 when the window was successfully un-minimized so the caller can
+// retry after Dock animation, or 1 after attempting the normal raise path.
+static int restoreAndRaiseWindow(AXUIElementRef appEl, AXUIElementRef window) {
+	CFTypeRef minRef = NULL;
+	if (AXUIElementCopyAttributeValue(window, CFSTR("AXMinimized"), &minRef) == kAXErrorSuccess && minRef) {
+		if (CFGetTypeID(minRef) == CFBooleanGetTypeID() && CFBooleanGetValue((CFBooleanRef)minRef)) {
+			AXError err = AXUIElementSetAttributeValue(window, CFSTR("AXMinimized"), kCFBooleanFalse);
+			CFRelease(minRef);
+			if (err == kAXErrorSuccess) {
+				return 2;
+			}
+		} else {
+			CFRelease(minRef);
+		}
+	}
+
+	AXUIElementPerformAction(window, CFSTR("AXRaise"));
+	AXUIElementSetAttributeValue(appEl, CFSTR("AXFrontmost"), kCFBooleanTrue);
+	return 1;
+}
+
 // raiseWindowByAXDocument enumerates AXWindows for the given PID and raises
 // the first window whose AXDocument attribute exactly matches fileURL. Ghostty
 // sets AXDocument to the shell CWD (via OSC 7) as a file:// URL.
-// Returns 1 on match, 0 if not found, -1 if Accessibility permission is missing.
+// Returns 1 after raising, 2 when a minimized window was restored and should be
+// retried, 0 if not found, -1 if Accessibility permission is missing.
 // NOTE: AXWindows only populates after the app has been activated; callers
 // must call activateByPID and wait before calling this function.
 static int raiseWindowByAXDocument(int pid, const char *fileURL) {
@@ -156,12 +179,11 @@ static int raiseWindowByAXDocument(int pid, const char *fileURL) {
 		CFRelease(docRef);
 
 		if (ok && strcmp(buf, fileURL) == 0) {
-			AXUIElementPerformAction(w, CFSTR("AXRaise"));
-			AXUIElementSetAttributeValue(appEl, CFSTR("AXFrontmost"), kCFBooleanTrue);
-			found = 1;
+			found = restoreAndRaiseWindow(appEl, w);
+			free(buf);
+			break;
 		}
 		free(buf);
-		if (found) break;
 	}
 
 	CFRelease(windowsRef);
@@ -191,7 +213,8 @@ static int findSwitchAndActivate(int pid, const char *folderName) {
 
 // raiseWindowByAXTitle enumerates AXWindows for the given PID and raises the
 // first window whose AXTitle contains folderName as a distinct component.
-// Returns 1 on match, 0 if not found, -1 if Accessibility permission is missing.
+// Returns 1 after raising, 2 when a minimized window was restored and should be
+// retried, 0 if not found, -1 if Accessibility permission is missing.
 static int raiseWindowByAXTitle(int pid, const char *folderName) {
 	if (!AXIsProcessTrusted()) {
 		return -1;
@@ -220,9 +243,7 @@ static int raiseWindowByAXTitle(int pid, const char *folderName) {
 		BOOL matched = titleMatchesFolder(title, folder);
 		CFRelease(titleRef);
 		if (matched) {
-			AXUIElementPerformAction(w, CFSTR("AXRaise"));
-			AXUIElementSetAttributeValue(appEl, CFSTR("AXFrontmost"), kCFBooleanTrue);
-			found = 1;
+			found = restoreAndRaiseWindow(appEl, w);
 			break;
 		}
 	}
@@ -244,21 +265,42 @@ import (
 	"github.com/777genius/claude-notifications/internal/config"
 )
 
+const windowFocusRetryAfterRestore = 2
+
 // retryWindowFocus calls fn with increasing delays until a non-zero result.
 // Returns 1 (found), -1 (no permission), or 0 (not found after all attempts).
 // Worst case: 150+250+400 = 800ms. Best case: 150ms.
 func retryWindowFocus(fn func() C.int) C.int {
-	delays := []time.Duration{
+	result := retryWindowFocusWithDelays(func() int {
+		return int(fn())
+	}, []time.Duration{
 		150 * time.Millisecond,
 		250 * time.Millisecond,
 		400 * time.Millisecond,
-	}
-	var result C.int
+	}, time.Sleep)
+	return C.int(result)
+}
+
+func retryWindowFocusWithDelays(fn func() int, delays []time.Duration, sleep func(time.Duration)) int {
+	var result int
+	needsPostRestoreRetry := false
 	for _, d := range delays {
-		time.Sleep(d)
+		sleep(d)
 		result = fn()
+		if result == windowFocusRetryAfterRestore {
+			needsPostRestoreRetry = true
+			continue
+		}
+		needsPostRestoreRetry = false
 		if result != 0 {
 			break
+		}
+	}
+	if needsPostRestoreRetry && len(delays) > 0 {
+		sleep(delays[len(delays)-1])
+		result = fn()
+		if result == windowFocusRetryAfterRestore {
+			return 0
 		}
 	}
 	return result

--- a/internal/notifier/ax_focus_darwin_test.go
+++ b/internal/notifier/ax_focus_darwin_test.go
@@ -1,0 +1,129 @@
+//go:build darwin
+
+package notifier
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetryWindowFocusWithDelays_SucceedsAfterRetries(t *testing.T) {
+	t.Helper()
+
+	delays := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	var slept []time.Duration
+	calls := 0
+
+	result := retryWindowFocusWithDelays(func() int {
+		calls++
+		if calls < 3 {
+			return 0
+		}
+		return 1
+	}, delays, func(d time.Duration) {
+		slept = append(slept, d)
+	})
+
+	if result != 1 {
+		t.Fatalf("retryWindowFocusWithDelays() = %d, want 1", result)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts, got %d", calls)
+	}
+	if len(slept) != 3 {
+		t.Fatalf("expected 3 sleeps, got %d", len(slept))
+	}
+	for i, want := range delays {
+		if slept[i] != want {
+			t.Fatalf("sleep %d = %v, want %v", i, slept[i], want)
+		}
+	}
+}
+
+func TestRetryWindowFocusWithDelays_ExhaustsRetries(t *testing.T) {
+	t.Helper()
+
+	delays := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	sleeps := 0
+	calls := 0
+
+	result := retryWindowFocusWithDelays(func() int {
+		calls++
+		return 0
+	}, delays, func(time.Duration) {
+		sleeps++
+	})
+
+	if result != 0 {
+		t.Fatalf("retryWindowFocusWithDelays() = %d, want 0", result)
+	}
+	if calls != len(delays) {
+		t.Fatalf("expected %d attempts, got %d", len(delays), calls)
+	}
+	if sleeps != len(delays) {
+		t.Fatalf("expected %d sleeps, got %d", len(delays), sleeps)
+	}
+}
+
+func TestRetryWindowFocusWithDelays_ShortCircuitsOnPermissionError(t *testing.T) {
+	t.Helper()
+
+	delays := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	sleeps := 0
+	calls := 0
+
+	result := retryWindowFocusWithDelays(func() int {
+		calls++
+		return -1
+	}, delays, func(time.Duration) {
+		sleeps++
+	})
+
+	if result != -1 {
+		t.Fatalf("retryWindowFocusWithDelays() = %d, want -1", result)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 attempt, got %d", calls)
+	}
+	if sleeps != 1 {
+		t.Fatalf("expected 1 sleep, got %d", sleeps)
+	}
+}
+
+func TestRetryWindowFocusWithDelays_RestoredOnLastAttemptGetsExtraRetry(t *testing.T) {
+	t.Helper()
+
+	delays := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}
+	var slept []time.Duration
+	calls := 0
+
+	result := retryWindowFocusWithDelays(func() int {
+		calls++
+		switch calls {
+		case 1, 2:
+			return 0
+		case 3:
+			return windowFocusRetryAfterRestore
+		case 4:
+			return 1
+		default:
+			t.Fatalf("unexpected extra attempt %d", calls)
+			return 0
+		}
+	}, delays, func(d time.Duration) {
+		slept = append(slept, d)
+	})
+
+	if result != 1 {
+		t.Fatalf("retryWindowFocusWithDelays() = %d, want 1", result)
+	}
+	if calls != 4 {
+		t.Fatalf("expected 4 attempts including post-restore retry, got %d", calls)
+	}
+	if len(slept) != 4 {
+		t.Fatalf("expected 4 sleeps including post-restore retry, got %d", len(slept))
+	}
+	if slept[3] != delays[len(delays)-1] {
+		t.Fatalf("post-restore sleep = %v, want %v", slept[3], delays[len(delays)-1])
+	}
+}


### PR DESCRIPTION
## Summary
- restore minimized macOS windows before attempting AXRaise
- reuse the existing retry flow so Dock restore animation gets a follow-up focus attempt
- add darwin unit coverage for retry semantics and the post-restore extra retry case

## Validation
- go test ./internal/notifier -count=1
- swift test --package-path swift-notifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS window focus handling to better restore minimized windows and improve the reliability of bringing windows to the foreground.

* **Tests**
  * Added test coverage for window focus operations on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->