### PR TITLE
Fix/ghostty session focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 [![codecov](https://codecov.io/gh/777genius/claude-notifications-go/branch/main/graph/badge.svg)](https://codecov.io/gh/777genius/claude-notifications-go)
 
 <div>
-<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/e7aa6d8e-5d28-48f7-bafe-ad696857b938" />
-<img width="350" alt="image" src="https://i.imgur.com/Nrt6dEo.png" />
-<img width="220" alt="image" src="https://github.com/user-attachments/assets/4b5929d8-1a51-4a15-a3d5-dda5482554cc" />
+<table>
+  <tr>
+    <td align="center"><img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/e7aa6d8e-5d28-48f7-bafe-ad696857b938" /></td>
+    <td align="center"><img width="350" alt="image" src="https://i.imgur.com/Nrt6dEo.png" /></td>
+    <td align="center"><img width="220" alt="image" src="https://github.com/user-attachments/assets/4b5929d8-1a51-4a15-a3d5-dda5482554cc" /></td>
+  </tr>
+</table>
 </div>
 
 Smart notifications for Claude Code with click-to-focus, git branch display, and webhook integrations.

--- a/cmd/claude-notifications/main.go
+++ b/cmd/claude-notifications/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/777genius/claude-notifications/internal/audio"
 	"github.com/777genius/claude-notifications/internal/errorhandler"
@@ -58,6 +60,8 @@ func main() {
 		runPlaySound(os.Args[2:])
 	case "daemon", "--daemon":
 		runDaemon()
+	case "windows-hooks":
+		runWindowsHooks(os.Args[2:])
 	case "version", "--version", "-v":
 		fmt.Printf("claude-notifications v%s\n", version)
 	case "help", "--help", "-h":
@@ -67,6 +71,125 @@ func main() {
 		printUsage()
 		os.Exit(1)
 	}
+}
+
+type hookSettings struct {
+	Hooks map[string][]hookMatcherGroup `json:"hooks"`
+}
+
+type hookMatcherGroup struct {
+	Matcher string        `json:"matcher,omitempty"`
+	Hooks   []hookCommand `json:"hooks"`
+}
+
+type hookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout"`
+	Shell   string `json:"shell"`
+}
+
+func runWindowsHooks(args []string) {
+	exePath, err := parseWindowsHooksExecutable(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "windows-hooks: %v\n", err)
+		os.Exit(1)
+	}
+
+	settings := hookSettings{
+		Hooks: map[string][]hookMatcherGroup{
+			"PreToolUse": {
+				{
+					Matcher: "ExitPlanMode|AskUserQuestion",
+					Hooks:   []hookCommand{newPowerShellHook(exePath, "PreToolUse")},
+				},
+			},
+			"Notification": {
+				{
+					Matcher: "permission_prompt",
+					Hooks:   []hookCommand{newPowerShellHook(exePath, "Notification")},
+				},
+			},
+			"Stop": {
+				{
+					Hooks: []hookCommand{newPowerShellHook(exePath, "Stop")},
+				},
+			},
+			"SubagentStop": {
+				{
+					Hooks: []hookCommand{newPowerShellHook(exePath, "SubagentStop")},
+				},
+			},
+			"TeammateIdle": {
+				{
+					Hooks: []hookCommand{newPowerShellHook(exePath, "TeammateIdle")},
+				},
+			},
+		},
+	}
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "windows-hooks: failed to render JSON: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(out))
+}
+
+func parseWindowsHooksExecutable(args []string) (string, error) {
+	exeOverride := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--exe":
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("--exe requires a path")
+			}
+			i++
+			exeOverride = args[i]
+		default:
+			return "", fmt.Errorf("unknown windows-hooks option: %s", args[i])
+		}
+	}
+
+	if exeOverride != "" {
+		return filepath.Abs(exeOverride)
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to detect executable path: %w", err)
+	}
+
+	exePath, err = filepath.Abs(exePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+
+	if strings.EqualFold(filepath.Ext(exePath), ".exe") {
+		return exePath, nil
+	}
+
+	pluginRoot := getPluginRoot()
+	return filepath.Abs(filepath.Join(pluginRoot, "bin", "claude-notifications-windows-amd64.exe"))
+}
+
+func newPowerShellHook(exePath, hookName string) hookCommand {
+	return hookCommand{
+		Type:    "command",
+		Command: "$input | & " + powershellDoubleQuoted(exePath) + " handle-hook " + hookName,
+		Timeout: 30,
+		Shell:   "powershell",
+	}
+}
+
+func powershellDoubleQuoted(value string) string {
+	replacer := strings.NewReplacer(
+		"`", "``",
+		"$", "`$",
+		"\"", "`\"",
+	)
+	return `"` + replacer.Replace(value) + `"`
 }
 
 func handleHook(hookEvent string) {
@@ -194,6 +317,7 @@ func printUsage() {
 	fmt.Println("Usage:")
 	fmt.Println("  claude-notifications handle-hook <HookName>")
 	fmt.Println("  claude-notifications daemon")
+	fmt.Println("  claude-notifications windows-hooks [--exe <path>]")
 	fmt.Println("  claude-notifications version")
 	fmt.Println("  claude-notifications help")
 	fmt.Println()
@@ -204,6 +328,8 @@ func printUsage() {
 	fmt.Println("                          For click-to-focus support on desktop notifications")
 	fmt.Println("  focus-window <bundleID> <cwd> [--ghostty-terminal-id <id>]")
 	fmt.Println("                          Focus specific app window (internal, used by click-to-focus)")
+	fmt.Println("  windows-hooks           Print PowerShell hook JSON for Windows settings")
+	fmt.Println("                          Does not modify ~/.claude/settings.json")
 	fmt.Println("  version                 Show version information")
 	fmt.Println("  help                    Show this help message")
 	fmt.Println()
@@ -216,6 +342,9 @@ func printUsage() {
 	fmt.Println()
 	fmt.Println("  # Run notification daemon (Linux only, started automatically)")
 	fmt.Println("  claude-notifications daemon")
+	fmt.Println()
+	fmt.Println("  # Print Windows PowerShell hook configuration")
+	fmt.Println("  claude-notifications windows-hooks")
 	fmt.Println()
 	fmt.Println("Environment Variables:")
 	fmt.Println("  CLAUDE_PLUGIN_ROOT  Plugin root directory (auto-detected if not set)")

--- a/cmd/claude-notifications/main.go
+++ b/cmd/claude-notifications/main.go
@@ -45,7 +45,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: focus-window requires bundleID and cwd arguments\n")
 			os.Exit(1)
 		}
-		if err := notifier.FocusAppWindow(os.Args[2], os.Args[3]); err != nil {
+		opts, err := parseFocusWindowOptions(os.Args[4:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "focus-window: %v\n", err)
+			os.Exit(1)
+		}
+		if err := notifier.FocusAppWindowWithOptions(os.Args[2], os.Args[3], opts); err != nil {
 			fmt.Fprintf(os.Stderr, "focus-window: %v\n", err)
 			os.Exit(1)
 		}
@@ -162,6 +167,25 @@ func runPlaySound(args []string) {
 	}
 }
 
+func parseFocusWindowOptions(args []string) (notifier.FocusWindowOptions, error) {
+	var opts notifier.FocusWindowOptions
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--ghostty-terminal-id":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--ghostty-terminal-id requires a value")
+			}
+			i++
+			opts.GhosttyTerminalID = args[i]
+		default:
+			return opts, fmt.Errorf("unknown focus-window option: %s", args[i])
+		}
+	}
+
+	return opts, nil
+}
+
 func printUsage() {
 	fmt.Println("claude-notifications - Smart notifications for Claude Code")
 	fmt.Println()
@@ -178,7 +202,7 @@ func printUsage() {
 	fmt.Println("                          HookName: PreToolUse, Stop, SubagentStop, Notification")
 	fmt.Println("  daemon                  Run the notification daemon (Linux only)")
 	fmt.Println("                          For click-to-focus support on desktop notifications")
-	fmt.Println("  focus-window <bundleID> <cwd>")
+	fmt.Println("  focus-window <bundleID> <cwd> [--ghostty-terminal-id <id>]")
 	fmt.Println("                          Focus specific app window (internal, used by click-to-focus)")
 	fmt.Println("  version                 Show version information")
 	fmt.Println("  help                    Show this help message")

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,6 +96,113 @@ If your temp directory is on a different drive than your user profile (or where 
 
 Make sure `%TEMP%` and `%TMP%` point to a directory on the same drive as `%USERPROFILE%` (or where Claude stores its plugin directories), then restart your terminal/app.
 
+## Windows: hooks do not fire or notifications are silent
+
+### Symptom
+
+The plugin is installed and the Windows executable exists, but Claude Code does not show notifications for `Stop`, `ExitPlanMode`, `AskUserQuestion`, or `permission_prompt`. Claude Code debug logs may show hook command failures, or the hook may fail silently.
+
+### Why it happens
+
+The bundled plugin hook configuration uses `bin/hook-wrapper.sh`. On some Windows 11 Claude Code environments, bash/shebang resolution, `${CLAUDE_PLUGIN_ROOT}` expansion, or Unix-only paths like `/dev/tty` are not reliable enough for command hooks.
+
+Claude Code supports PowerShell command hooks on Windows via `"shell": "powershell"`, so the safer Windows workaround is to call the native `.exe` directly with an absolute path.
+
+### Fix (recommended)
+
+Generate a PowerShell hook configuration from the installed executable:
+
+```powershell
+.\bin\claude-notifications-windows-amd64.exe windows-hooks
+```
+
+If you downloaded the executable to a different location, pass it explicitly:
+
+```powershell
+.\bin\claude-notifications-windows-amd64.exe windows-hooks --exe "C:\absolute\path\to\claude-notifications-windows-amd64.exe"
+```
+
+Copy the generated `"hooks"` object into `%USERPROFILE%\.claude\settings.json`. This command only prints JSON - it does not modify your settings file.
+
+### Manual fallback
+
+If you cannot run `windows-hooks`, add this block manually and replace `<absolute-path-to-plugin>` with the actual plugin install directory:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "ExitPlanMode|AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook PreToolUse",
+            "timeout": 30,
+            "shell": "powershell"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook Notification",
+            "timeout": 30,
+            "shell": "powershell"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook Stop",
+            "timeout": 30,
+            "shell": "powershell"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook SubagentStop",
+            "timeout": 30,
+            "shell": "powershell"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook TeammateIdle",
+            "timeout": 30,
+            "shell": "powershell"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This workaround is based on confirmed Windows 11 behavior from [issue #73](https://github.com/777genius/claude-notifications-go/issues/73#issuecomment-4364271319).
+
+### Note about beeep logs
+
+If the log contains `beeep.Notify failed on windows: doc.LoadXml(tmpl)` but the toast still appears, treat it as a harmless Windows notifier false positive. Investigate it only if no popup appears.
+
 ## Windows / Git Bash: binary download fails from GitHub Releases
 
 ### Symptom

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -144,6 +144,14 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 		logging.Warn("Session ID is empty, using 'unknown'")
 	}
 
+	if h.cfg.Notifications.Desktop.ClickToFocus && (hookEvent == "PreToolUse" || hookEvent == "Notification") {
+		notifier.MaybeCaptureGhosttyTerminalID(
+			h.cfg.Notifications.Desktop.TerminalBundleID,
+			hookData.SessionID,
+			hookData.CWD,
+		)
+	}
+
 	// Phase 1: Early duplicate check (per hook event type)
 	bench.Start("dedup.early_check")
 	if h.dedupMgr.CheckEarlyDuplicate(hookData.SessionID, hookEvent) {

--- a/internal/notifier/ax_focus_darwin.go
+++ b/internal/notifier/ax_focus_darwin.go
@@ -274,6 +274,11 @@ const windowFocusRetryAfterRestore = 2
 const ghosttyAppleScriptFocusTimeout = 1500 * time.Millisecond
 
 var ghosttyAppleScriptRunner = runGhosttyAppleScriptFocus
+var ghosttyAppleScriptIDRunner = runGhosttyAppleScriptFocusByID
+
+type FocusWindowOptions struct {
+	GhosttyTerminalID string
+}
 
 // retryWindowFocus calls fn with increasing delays until a non-zero result.
 // Returns 1 (found), -1 (no permission), or 0 (not found after all attempts).
@@ -315,11 +320,15 @@ func retryWindowFocusWithDelays(fn func() int, delays []time.Duration, sleep fun
 }
 
 // FocusAppWindow raises the window matching cwd for the given bundleID app.
-// For Ghostty: first tries exact terminal/tab focus via AppleScript, then falls
-// back to AXDocument (OSC 7 file:// URL) if Automation is unavailable or no
-// exact terminal match is found.
+// For Ghostty: first tries an exact terminal ID match when available, then
+// falls back to exact AppleScript cwd matching, then finally AXDocument
+// (OSC 7 file:// URL) if Automation is unavailable or no exact match is found.
 // For other apps: uses CGS to find the window across Spaces then raises via AXTitle. macOS only.
 func FocusAppWindow(bundleID, cwd string) error {
+	return FocusAppWindowWithOptions(bundleID, cwd, FocusWindowOptions{})
+}
+
+func FocusAppWindowWithOptions(bundleID, cwd string, opts FocusWindowOptions) error {
 	cBundleID := C.CString(bundleID)
 	defer C.free(unsafe.Pointer(cBundleID))
 
@@ -332,7 +341,7 @@ func FocusAppWindow(bundleID, cwd string) error {
 		if cwd == "" {
 			return fmt.Errorf("invalid cwd: %s", cwd)
 		}
-		return focusGhosttyWindow(pid, bundleID, cwd, tryGhosttyAppleScriptFocus, focusGhosttyWindowByAXDocument)
+		return focusGhosttyWindowWithOptions(pid, bundleID, cwd, opts, tryGhosttyExactFocus, focusGhosttyWindowByAXDocument)
 	}
 
 	folderName := filepath.Base(cwd)
@@ -381,12 +390,41 @@ func focusGhosttyWindow(
 	exactFocus func(string) error,
 	fallback func(int, string, string) error,
 ) error {
-	if err := exactFocus(cwd); err == nil {
+	return focusGhosttyWindowWithOptions(
+		pid,
+		bundleID,
+		cwd,
+		FocusWindowOptions{},
+		func(cwd string, _ FocusWindowOptions) error { return exactFocus(cwd) },
+		fallback,
+	)
+}
+
+func focusGhosttyWindowWithOptions(
+	pid int,
+	bundleID, cwd string,
+	opts FocusWindowOptions,
+	exactFocus func(string, FocusWindowOptions) error,
+	fallback func(int, string, string) error,
+) error {
+	if err := exactFocus(cwd, opts); err == nil {
 		return nil
 	} else {
 		logging.Debug("Ghostty exact tab focus unavailable, falling back to AXDocument: %v", err)
 	}
 	return fallback(pid, bundleID, cwd)
+}
+
+func tryGhosttyExactFocus(cwd string, opts FocusWindowOptions) error {
+	if terminalID := strings.TrimSpace(opts.GhosttyTerminalID); terminalID != "" {
+		if err := ghosttyAppleScriptIDRunner(terminalID); err == nil {
+			return nil
+		} else {
+			logging.Debug("Ghostty terminal-id focus failed for %s, falling back to cwd match: %v", terminalID, err)
+		}
+	}
+
+	return tryGhosttyAppleScriptFocus(cwd)
 }
 
 func tryGhosttyAppleScriptFocus(cwd string) error {
@@ -395,6 +433,35 @@ func tryGhosttyAppleScriptFocus(cwd string) error {
 		return fmt.Errorf("invalid cwd: %s", cwd)
 	}
 	return ghosttyAppleScriptRunner(candidates)
+}
+
+func runGhosttyAppleScriptFocusByID(terminalID string) error {
+	if strings.TrimSpace(terminalID) == "" {
+		return fmt.Errorf("empty Ghostty terminal ID")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ghosttyAppleScriptFocusTimeout)
+	defer cancel()
+
+	output, err := exec.CommandContext(
+		ctx,
+		"/usr/bin/osascript",
+		"-e",
+		ghosttyFocusByIDAppleScript,
+		"--",
+		terminalID,
+	).CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("Ghostty terminal-id AppleScript timed out after %s", ghosttyAppleScriptFocusTimeout)
+	}
+	if err != nil {
+		outputText := strings.TrimSpace(string(output))
+		if outputText == "" {
+			return fmt.Errorf("Ghostty terminal-id AppleScript failed: %w", err)
+		}
+		return fmt.Errorf("Ghostty terminal-id AppleScript failed: %w: %s", err, outputText)
+	}
+	return nil
 }
 
 func runGhosttyAppleScriptFocus(candidates []string) error {
@@ -511,6 +578,29 @@ on run argv
 		return
 	end if
 	error "ghostty terminal not found" number 1001
+end run
+`
+
+const ghosttyFocusByIDAppleScript = `
+on run argv
+	if (count of argv) is 0 then
+		error "missing Ghostty terminal id" number 1002
+	end if
+
+	set wantedID to item 1 of argv
+
+	tell application "Ghostty"
+		repeat with t in terminals
+			try
+				if (id of t as string) is wantedID then
+					focus t
+					return
+				end if
+			end try
+		end repeat
+	end tell
+
+	error "ghostty terminal id not found" number 1002
 end run
 `
 

--- a/internal/notifier/ax_focus_darwin_test.go
+++ b/internal/notifier/ax_focus_darwin_test.go
@@ -254,3 +254,59 @@ func TestTryGhosttyAppleScriptFocus_UsesNormalizedCandidates(t *testing.T) {
 		t.Fatalf("runner candidates = %#v, want %#v", gotCandidates, wantCandidates)
 	}
 }
+
+func TestTryGhosttyExactFocus_PrefersTerminalID(t *testing.T) {
+	originalIDRunner := ghosttyAppleScriptIDRunner
+	originalRunner := ghosttyAppleScriptRunner
+	t.Cleanup(func() {
+		ghosttyAppleScriptIDRunner = originalIDRunner
+		ghosttyAppleScriptRunner = originalRunner
+	})
+
+	gotID := ""
+	ghosttyAppleScriptIDRunner = func(terminalID string) error {
+		gotID = terminalID
+		return nil
+	}
+	ghosttyAppleScriptRunner = func(candidates []string) error {
+		t.Fatalf("cwd fallback should not run when terminal ID succeeds, got %#v", candidates)
+		return nil
+	}
+
+	err := tryGhosttyExactFocus("/tmp/project", FocusWindowOptions{GhosttyTerminalID: "term-7"})
+	if err != nil {
+		t.Fatalf("tryGhosttyExactFocus returned error: %v", err)
+	}
+	if gotID != "term-7" {
+		t.Fatalf("terminal ID = %q, want term-7", gotID)
+	}
+}
+
+func TestTryGhosttyExactFocus_FallsBackToCWDWhenTerminalIDFails(t *testing.T) {
+	originalIDRunner := ghosttyAppleScriptIDRunner
+	originalRunner := ghosttyAppleScriptRunner
+	t.Cleanup(func() {
+		ghosttyAppleScriptIDRunner = originalIDRunner
+		ghosttyAppleScriptRunner = originalRunner
+	})
+
+	ghosttyAppleScriptIDRunner = func(terminalID string) error {
+		return errors.New("not found")
+	}
+
+	var gotCandidates []string
+	ghosttyAppleScriptRunner = func(candidates []string) error {
+		gotCandidates = append([]string(nil), candidates...)
+		return nil
+	}
+
+	err := tryGhosttyExactFocus("/tmp/project", FocusWindowOptions{GhosttyTerminalID: "term-7"})
+	if err != nil {
+		t.Fatalf("tryGhosttyExactFocus returned error: %v", err)
+	}
+
+	wantCandidates := []string{"/tmp/project"}
+	if !reflect.DeepEqual(gotCandidates, wantCandidates) {
+		t.Fatalf("runner candidates = %#v, want %#v", gotCandidates, wantCandidates)
+	}
+}

--- a/internal/notifier/ax_focus_stub.go
+++ b/internal/notifier/ax_focus_stub.go
@@ -8,3 +8,12 @@ import "fmt"
 func FocusAppWindow(bundleID, cwd string) error {
 	return fmt.Errorf("focus-window not supported on this platform")
 }
+
+// FocusAppWindowWithOptions is not supported on non-darwin platforms.
+func FocusAppWindowWithOptions(bundleID, cwd string, opts FocusWindowOptions) error {
+	return fmt.Errorf("focus-window not supported on this platform")
+}
+
+type FocusWindowOptions struct {
+	GhosttyTerminalID string
+}

--- a/internal/notifier/ghostty_session_darwin.go
+++ b/internal/notifier/ghostty_session_darwin.go
@@ -1,0 +1,202 @@
+//go:build darwin
+
+package notifier
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/777genius/claude-notifications/internal/logging"
+	"github.com/777genius/claude-notifications/internal/state"
+)
+
+const ghosttyFrontmostTerminalInfoTimeout = 1500 * time.Millisecond
+
+type ghosttyFrontmostTerminalInfo struct {
+	ID               string
+	WorkingDirectory string
+	Name             string
+}
+
+type ghosttyWorktreeContext struct {
+	RepoRoot     string
+	WorktreeName string
+}
+
+var ghosttyFrontmostTerminalInfoRunner = readGhosttyFrontmostTerminalInfo
+
+// MaybeCaptureGhosttyTerminalID stores the current Ghostty terminal ID for the
+// Claude session when we can confidently prove the frontmost Ghostty terminal is
+// the active Claude session that emitted this hook.
+func MaybeCaptureGhosttyTerminalID(configOverride, sessionID, cwd string) {
+	if sessionID == "" || cwd == "" {
+		return
+	}
+	if !isGhosttyBundleID(GetTerminalBundleID(configOverride)) {
+		return
+	}
+
+	info, err := ghosttyFrontmostTerminalInfoRunner()
+	if err != nil {
+		logging.Debug("Ghostty terminal capture skipped: %v", err)
+		return
+	}
+	if !ghosttyFrontmostTerminalMatchesSession(info, cwd) {
+		logging.Debug("Ghostty terminal capture skipped: frontmost terminal did not match session cwd=%q name=%q dir=%q", cwd, info.Name, info.WorkingDirectory)
+		return
+	}
+
+	if err := state.NewManager().UpdateGhosttyTerminalID(sessionID, info.ID); err != nil {
+		logging.Warn("Failed to persist Ghostty terminal ID for session %s: %v", sessionID, err)
+		return
+	}
+	logging.Debug("Captured Ghostty terminal ID %s for session %s", info.ID, sessionID)
+}
+
+func loadStoredGhosttyTerminalID(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+
+	sessionState, err := state.NewManager().Load(sessionID)
+	if err != nil || sessionState == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(sessionState.GhosttyTerminalID)
+}
+
+func ghosttyFrontmostTerminalMatchesSession(info ghosttyFrontmostTerminalInfo, cwd string) bool {
+	if strings.TrimSpace(info.ID) == "" {
+		return false
+	}
+
+	normalizedTermDir := normalizeGhosttyWorkingDir(info.WorkingDirectory)
+	if normalizedTermDir == "" {
+		return false
+	}
+
+	lowerName := strings.ToLower(strings.TrimSpace(info.Name))
+	if !strings.Contains(lowerName, "claude") {
+		return false
+	}
+
+	for _, candidate := range ghosttyFocusCandidates(cwd) {
+		if normalizedTermDir == candidate {
+			return true
+		}
+	}
+
+	worktreeCtx, ok := deriveGhosttyWorktreeContext(cwd)
+	if !ok {
+		return false
+	}
+	if normalizedTermDir != worktreeCtx.RepoRoot {
+		return false
+	}
+
+	return ghosttyTerminalNameMatchesWorktree(lowerName, worktreeCtx.WorktreeName)
+}
+
+func deriveGhosttyWorktreeContext(cwd string) (ghosttyWorktreeContext, bool) {
+	normalized := strings.ReplaceAll(normalizeGhosttyWorkingDir(cwd), "\\", "/")
+	const marker = "/.claude/worktrees/"
+
+	idx := strings.Index(normalized, marker)
+	if idx <= 0 {
+		return ghosttyWorktreeContext{}, false
+	}
+
+	repoRoot := normalizeGhosttyWorkingDir(normalized[:idx])
+	worktreeName := strings.Trim(strings.TrimPrefix(normalized[idx+len(marker):], "/"), "/")
+	if repoRoot == "" || worktreeName == "" {
+		return ghosttyWorktreeContext{}, false
+	}
+
+	return ghosttyWorktreeContext{
+		RepoRoot:     repoRoot,
+		WorktreeName: worktreeName,
+	}, true
+}
+
+func ghosttyTerminalNameMatchesWorktree(lowerName, worktreeName string) bool {
+	return ghosttyTerminalNameContainsWorktree(lowerName, worktreeName) ||
+		ghosttyTerminalNameContainsWorktree(lowerName, path.Base(worktreeName))
+}
+
+func ghosttyTerminalNameContainsWorktree(name, worktreeName string) bool {
+	label := strings.ToLower(strings.TrimSpace(worktreeName))
+	if label == "" {
+		return false
+	}
+
+	patterns := []string{
+		"-w " + label,
+		"-w=" + label,
+		"--worktree " + label,
+		"--worktree=" + label,
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(name, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func readGhosttyFrontmostTerminalInfo() (ghosttyFrontmostTerminalInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ghosttyFrontmostTerminalInfoTimeout)
+	defer cancel()
+
+	output, err := exec.CommandContext(ctx, "/usr/bin/osascript", "-e", ghosttyFrontmostTerminalInfoAppleScript).CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return ghosttyFrontmostTerminalInfo{}, fmt.Errorf("Ghostty frontmost terminal lookup timed out after %s", ghosttyFrontmostTerminalInfoTimeout)
+	}
+	if err != nil {
+		outputText := strings.TrimSpace(string(output))
+		if outputText == "" {
+			return ghosttyFrontmostTerminalInfo{}, fmt.Errorf("Ghostty frontmost terminal lookup failed: %w", err)
+		}
+		return ghosttyFrontmostTerminalInfo{}, fmt.Errorf("Ghostty frontmost terminal lookup failed: %w: %s", err, outputText)
+	}
+
+	outputText := strings.TrimRight(string(output), "\r\n")
+	parts := strings.SplitN(outputText, "\x1f", 3)
+	if len(parts) != 3 {
+		return ghosttyFrontmostTerminalInfo{}, fmt.Errorf("unexpected Ghostty frontmost terminal response: %q", outputText)
+	}
+
+	return ghosttyFrontmostTerminalInfo{
+		ID:               strings.TrimSpace(parts[0]),
+		WorkingDirectory: strings.TrimSpace(parts[1]),
+		Name:             parts[2],
+	}, nil
+}
+
+const ghosttyFrontmostTerminalInfoAppleScript = `
+on normalizePath(thePath)
+	if thePath is "/" then
+		return "/"
+	end if
+	if thePath ends with "/" then
+		return text 1 thru -2 of thePath
+	end if
+	return thePath
+end normalizePath
+
+on run
+	tell application "Ghostty"
+		if not frontmost then
+			error "Ghostty not frontmost" number 1003
+		end if
+		set term to focused terminal of selected tab of front window
+		set delim to ASCII character 31
+		return ((id of term as string) & delim & (my normalizePath(working directory of term)) & delim & (name of term as string))
+	end tell
+end run
+`

--- a/internal/notifier/ghostty_session_darwin_test.go
+++ b/internal/notifier/ghostty_session_darwin_test.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+package notifier
+
+import (
+	"testing"
+
+	"github.com/777genius/claude-notifications/internal/state"
+)
+
+func TestGhosttyFrontmostTerminalMatchesSession_ExactCWD(t *testing.T) {
+	info := ghosttyFrontmostTerminalInfo{
+		ID:               "11",
+		WorkingDirectory: "/repo/project",
+		Name:             "claude",
+	}
+
+	if !ghosttyFrontmostTerminalMatchesSession(info, "/repo/project") {
+		t.Fatal("expected exact cwd match to be accepted")
+	}
+}
+
+func TestGhosttyFrontmostTerminalMatchesSession_ExactCWDRequiresClaudeTitle(t *testing.T) {
+	info := ghosttyFrontmostTerminalInfo{
+		ID:               "11",
+		WorkingDirectory: "/repo/project",
+		Name:             "zsh",
+	}
+
+	if ghosttyFrontmostTerminalMatchesSession(info, "/repo/project") {
+		t.Fatal("non-Claude frontmost terminal should not be captured")
+	}
+}
+
+func TestGhosttyFrontmostTerminalMatchesSession_WorktreeUsesRepoRootAndCommandTitle(t *testing.T) {
+	info := ghosttyFrontmostTerminalInfo{
+		ID:               "12",
+		WorkingDirectory: "/repo",
+		Name:             "claude -w feat/foo",
+	}
+
+	if !ghosttyFrontmostTerminalMatchesSession(info, "/repo/.claude/worktrees/feat/foo") {
+		t.Fatal("expected worktree session to match repo-root cwd plus claude -w title")
+	}
+}
+
+func TestGhosttyFrontmostTerminalMatchesSession_WorktreeRejectsMismatchedTitle(t *testing.T) {
+	info := ghosttyFrontmostTerminalInfo{
+		ID:               "13",
+		WorkingDirectory: "/repo",
+		Name:             "claude -w feat/bar",
+	}
+
+	if ghosttyFrontmostTerminalMatchesSession(info, "/repo/.claude/worktrees/feat/foo") {
+		t.Fatal("mismatched worktree title should not be accepted")
+	}
+}
+
+func TestMaybeCaptureGhosttyTerminalID_PersistsMatchedTerminal(t *testing.T) {
+	originalRunner := ghosttyFrontmostTerminalInfoRunner
+	t.Cleanup(func() {
+		ghosttyFrontmostTerminalInfoRunner = originalRunner
+	})
+
+	sessionID := "ghostty-capture-test"
+	t.Cleanup(func() {
+		_ = state.NewManager().Delete(sessionID)
+	})
+
+	ghosttyFrontmostTerminalInfoRunner = func() (ghosttyFrontmostTerminalInfo, error) {
+		return ghosttyFrontmostTerminalInfo{
+			ID:               "99",
+			WorkingDirectory: "/repo",
+			Name:             "claude -w feat/foo",
+		}, nil
+	}
+
+	MaybeCaptureGhosttyTerminalID("com.mitchellh.ghostty", sessionID, "/repo/.claude/worktrees/feat/foo")
+
+	if got := loadStoredGhosttyTerminalID(sessionID); got != "99" {
+		t.Fatalf("stored Ghostty terminal ID = %q, want 99", got)
+	}
+}

--- a/internal/notifier/ghostty_session_stub.go
+++ b/internal/notifier/ghostty_session_stub.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package notifier
+
+func MaybeCaptureGhosttyTerminalID(configOverride, sessionID, cwd string) {}
+
+func loadStoredGhosttyTerminalID(sessionID string) string {
+	return ""
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -176,6 +176,10 @@ func (n *Notifier) sendWithTerminalNotifier(title, message, subtitle, sessionID 
 	}
 
 	bundleID := GetTerminalBundleID(n.cfg.Notifications.Desktop.TerminalBundleID)
+	ghosttyTerminalID := ""
+	if clickToFocus && isGhosttyBundleID(bundleID) {
+		ghosttyTerminalID = loadStoredGhosttyTerminalID(sessionID)
+	}
 
 	var args []string
 	if muxArgs, muxName := detectMultiplexerArgs(title, message, bundleID); muxArgs != nil {
@@ -185,7 +189,7 @@ func (n *Notifier) sendWithTerminalNotifier(title, message, subtitle, sessionID 
 		if muxName != "" {
 			logging.Debug("%s detected but target capture failed, falling back to -activate", muxName)
 		}
-		args = buildTerminalNotifierArgs(title, message, bundleID, cwd, clickToFocus)
+		args = buildTerminalNotifierArgsWithOptions(title, message, bundleID, cwd, ghosttyTerminalID, clickToFocus)
 	}
 
 	// Append shared options: subtitle, threadID, timeSensitive, nosound
@@ -300,6 +304,10 @@ func claudeNotifierAppPath(notifierPath string) (string, bool) {
 // When cwd is provided, uses -execute with a focus script instead of -activate.
 // Exported for testing purposes.
 func buildTerminalNotifierArgs(title, message, bundleID, cwd string, clickToFocus bool) []string {
+	return buildTerminalNotifierArgsWithOptions(title, message, bundleID, cwd, "", clickToFocus)
+}
+
+func buildTerminalNotifierArgsWithOptions(title, message, bundleID, cwd, ghosttyTerminalID string, clickToFocus bool) []string {
 	args := []string{
 		"-title", title,
 		"-message", message,
@@ -308,7 +316,7 @@ func buildTerminalNotifierArgs(title, message, bundleID, cwd string, clickToFocu
 	if clickToFocus {
 		// Note: -sender option removed because it conflicts with -activate on macOS Sequoia (15.x)
 		// Using -sender causes click-to-focus to stop working.
-		if script := buildFocusScript(bundleID, cwd); script != "" {
+		if script := buildFocusScriptWithOptions(bundleID, cwd, ghosttyTerminalID); script != "" {
 			args = append(args, "-execute", script)
 		} else {
 			args = append(args, "-activate", bundleID)
@@ -329,6 +337,10 @@ func buildTerminalNotifierArgs(title, message, bundleID, cwd string, clickToFocu
 // raise the correct window across Spaces.
 // Returns "" when cwd is empty or unusable (caller should use -activate instead).
 func buildFocusScript(bundleID, cwd string) string {
+	return buildFocusScriptWithOptions(bundleID, cwd, "")
+}
+
+func buildFocusScriptWithOptions(bundleID, cwd, ghosttyTerminalID string) string {
 	if isIterm2BundleID(bundleID) {
 		return buildIterm2FocusScript(cwd)
 	}
@@ -337,7 +349,7 @@ func buildFocusScript(bundleID, cwd string) string {
 		if cwd == "" {
 			return ""
 		}
-		return buildGhosttyFocusScript(bundleID, cwd)
+		return buildGhosttyFocusScript(bundleID, cwd, ghosttyTerminalID)
 	}
 
 	if cwd == "" {
@@ -359,7 +371,7 @@ func buildFocusScript(bundleID, cwd string) string {
 	// The focus-window approach uses Accessibility + Screen Recording instead of Automation,
 	// with graceful fallback to app-level activation when permissions are not granted.
 	// See: https://github.com/777genius/claude-notifications-go/issues/47
-	return buildBinaryFocusScript(bundleID, cwd)
+	return buildBinaryFocusScript(bundleID, cwd, "")
 }
 
 // isElectronEditorBundleID reports whether bundleID belongs to an Electron-based
@@ -385,7 +397,7 @@ func shellQuote(s string) string {
 // buildBinaryFocusScript builds the -execute script for apps that use the
 // binary's focus-window subcommand (all macOS terminals including Electron editors and Ghostty).
 // Returns "" (causing -activate fallback) if os.Executable() fails.
-func buildBinaryFocusScript(bundleID, cwd string) string {
+func buildBinaryFocusScript(bundleID, cwd, ghosttyTerminalID string) string {
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
@@ -394,7 +406,11 @@ func buildBinaryFocusScript(bundleID, cwd string) string {
 	if err != nil {
 		return ""
 	}
-	return shellQuote(exe) + " focus-window " + shellQuote(bundleID) + " " + shellQuote(cwd)
+	cmd := shellQuote(exe) + " focus-window " + shellQuote(bundleID) + " " + shellQuote(cwd)
+	if isGhosttyBundleID(bundleID) && ghosttyTerminalID != "" {
+		cmd += " --ghostty-terminal-id " + shellQuote(ghosttyTerminalID)
+	}
+	return cmd
 }
 
 // buildElectronEditorFocusScript builds the -execute script for Electron-based
@@ -402,7 +418,7 @@ func buildBinaryFocusScript(bundleID, cwd string) string {
 // activates the app, waits for AXWindows to populate, then raises the window
 // matching cwd.
 func buildElectronEditorFocusScript(bundleID, cwd string) string {
-	return buildBinaryFocusScript(bundleID, cwd)
+	return buildBinaryFocusScript(bundleID, cwd, "")
 }
 
 // buildGhosttyFocusScript builds the -execute script for Ghostty.
@@ -410,8 +426,8 @@ func buildElectronEditorFocusScript(bundleID, cwd string) string {
 // waits for AXWindows to populate, then raises the window matching cwd via
 // AXDocument (OSC 7 file:// URL). AXDocument is window-level only; tabs and
 // split panes within a window are not individually addressable.
-func buildGhosttyFocusScript(bundleID, cwd string) string {
-	return buildBinaryFocusScript(bundleID, cwd)
+func buildGhosttyFocusScript(bundleID, cwd, ghosttyTerminalID string) string {
+	return buildBinaryFocusScript(bundleID, cwd, ghosttyTerminalID)
 }
 
 // cwdToFileURL converts an absolute path to a file:// URL. Ghostty exposes the

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1265,6 +1265,13 @@ func TestBuildFocusScript_Ghostty_UsesFocusWindow(t *testing.T) {
 	}
 }
 
+func TestBuildFocusScriptWithOptions_Ghostty_IncludesTerminalID(t *testing.T) {
+	script := buildFocusScriptWithOptions("com.mitchellh.ghostty", "/home/user/my-project", "terminal-42")
+	if !strings.Contains(script, "--ghostty-terminal-id 'terminal-42'") {
+		t.Fatalf("Ghostty focus script should pass exact terminal ID, got: %s", script)
+	}
+}
+
 func TestCwdToFileURL(t *testing.T) {
 	tests := []struct {
 		cwd      string

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,6 +20,7 @@ type SessionState struct {
 	LastNotificationTime    int64  `json:"last_notification_ts,omitempty"`
 	LastNotificationStatus  string `json:"last_notification_status,omitempty"`
 	LastNotificationMessage string `json:"last_notification_message,omitempty"`
+	GhosttyTerminalID       string `json:"ghostty_terminal_id,omitempty"`
 	CWD                     string `json:"cwd"`
 }
 
@@ -107,6 +108,25 @@ func (m *Manager) UpdateInteractiveTool(sessionID, toolName, cwd string) error {
 	state.LastInteractiveTool = toolName
 	state.LastTimestamp = platform.CurrentTimestamp()
 	state.CWD = cwd
+
+	return m.Save(state)
+}
+
+// UpdateGhosttyTerminalID stores the exact Ghostty terminal ID associated with a
+// Claude session so future notification clicks can target the correct tab.
+func (m *Manager) UpdateGhosttyTerminalID(sessionID, terminalID string) error {
+	state, err := m.Load(sessionID)
+	if err != nil {
+		return err
+	}
+
+	if state == nil {
+		state = &SessionState{
+			SessionID: sessionID,
+		}
+	}
+
+	state.GhosttyTerminalID = strings.TrimSpace(terminalID)
 
 	return m.Save(state)
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -135,6 +135,31 @@ func TestManager_UpdateInteractiveTool_ExistingState(t *testing.T) {
 	assert.Equal(t, int64(12345), state.LastTaskCompleteTime)
 }
 
+func TestManager_UpdateGhosttyTerminalID_PreservesExistingFields(t *testing.T) {
+	mgr := NewManager()
+	sessionID := "test-ghostty-terminal-id"
+	defer func() { _ = mgr.Delete(sessionID) }()
+
+	initial := &SessionState{
+		SessionID:           sessionID,
+		LastInteractiveTool: "ExitPlanMode",
+		CWD:                 "/test/dir",
+	}
+	err := mgr.Save(initial)
+	require.NoError(t, err)
+
+	err = mgr.UpdateGhosttyTerminalID(sessionID, "term-42")
+	require.NoError(t, err)
+
+	state, err := mgr.Load(sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	assert.Equal(t, "ExitPlanMode", state.LastInteractiveTool)
+	assert.Equal(t, "/test/dir", state.CWD)
+	assert.Equal(t, "term-42", state.GhosttyTerminalID)
+}
+
 // === UpdateTaskComplete Tests ===
 
 func TestManager_UpdateTaskComplete_NewState(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI command to output a Windows PowerShell hook configuration (JSON) for more reliable hooks on Windows.
  * Extended focus-window CLI options for finer control of window focusing.
  * Improved macOS Ghostty click-to-focus that can target and remember a specific terminal instance for more accurate focus behavior.

* **Documentation**
  * Added Windows troubleshooting and PowerShell hook setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->