### PR TITLE
fix: configure Windows hooks through PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Per-channel status overrides for desktop and webhook notifications** - each `statuses.<name>` entry can now define `desktop.enabled` and `webhook.enabled` independently, so you can disable webhook delivery for specific statuses while keeping desktop notifications on, or do the reverse ([#74](https://github.com/777genius/claude-notifications-go/issues/74))
 
 ### Fixed
+- **Windows: native hooks no longer depend on Git Bash script execution** - installer now rewrites PreToolUse, Notification, Stop, SubagentStop, and TeammateIdle hooks to call the native Windows `.exe` through PowerShell with an absolute path, avoiding silent `hook-wrapper.sh` launch failures on Windows 10/11 ([#79](https://github.com/777genius/claude-notifications-go/issues/79))
 - **CI stability for async webhook tests** - relaxed an overly strict `SendAsync` timing assertion under race-enabled CI, removing a macOS false negative without weakening the async behavior guarantee
 
 ## [1.37.0] - 2026-04-15

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -52,6 +52,7 @@ PINNED_RELEASE_TAG=""
 
 # Parse command line arguments
 FORCE_UPDATE=false
+WINDOWS_NATIVE_HOOKS_NEED_UPDATE=false
 for arg in "$@"; do
   case $arg in
     --force|-f)
@@ -559,6 +560,13 @@ check_existing() {
         return 1
     fi
     if [ -f "$BINARY_PATH" ]; then
+        if windows_native_hooks_update_required; then
+            WINDOWS_NATIVE_HOOKS_NEED_UPDATE=true
+            echo -e "${YELLOW}⚠ Existing Windows binary cannot generate PowerShell hooks${NC}"
+            echo -e "${YELLOW}  Updating ${BINARY_NAME} before rewriting hooks...${NC}"
+            return 1
+        fi
+
         echo -e "${GREEN}✓${NC} Binary already installed: ${BOLD}${BINARY_NAME}${NC}"
         echo ""
         return 0
@@ -950,6 +958,40 @@ make_executable() {
     chmod +x "$BINARY_PATH" 2>/dev/null || true
 }
 
+windows_hooks_path() {
+    local plugin_root
+    plugin_root="$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd)" || return 1
+    printf '%s\n' "${plugin_root}/hooks/hooks.json"
+}
+
+windows_native_hooks_json() {
+    [ "$PLATFORM" = "windows" ] || return 1
+    [ -f "$BINARY_PATH" ] || return 1
+
+    local exe_path="$BINARY_PATH"
+    if command -v cygpath >/dev/null 2>&1; then
+        exe_path="$(cygpath -w "$BINARY_PATH" 2>/dev/null || printf '%s' "$BINARY_PATH")"
+    fi
+
+    "$BINARY_PATH" windows-hooks --exe "$exe_path"
+}
+
+windows_native_hooks_supported() {
+    local hooks_json
+    hooks_json="$(windows_native_hooks_json 2>/dev/null)" || return 1
+    printf '%s\n' "$hooks_json" | grep -qE '"shell"[[:space:]]*:[[:space:]]*"powershell"'
+}
+
+windows_native_hooks_update_required() {
+    [ "$PLATFORM" = "windows" ] || return 1
+
+    local hooks_path
+    hooks_path="$(windows_hooks_path)" || return 1
+    [ -f "$hooks_path" ] || return 1
+
+    ! windows_native_hooks_supported
+}
+
 # Create symlink for hooks
 create_symlink() {
     # On Windows, create a .bat wrapper instead of symlink
@@ -1000,6 +1042,37 @@ EOF
         echo -e "${YELLOW}⚠ Could not create symlink/copy (hooks may not work)${NC}"
         return 1
     fi
+}
+
+configure_windows_native_hooks() {
+    [ "$PLATFORM" = "windows" ] || return 0
+    [ -f "$BINARY_PATH" ] || return 0
+
+    local hooks_path
+    hooks_path="$(windows_hooks_path)" || return 0
+    [ -f "$hooks_path" ] || return 0
+
+    local hooks_json
+    if ! hooks_json="$(windows_native_hooks_json 2>/dev/null)"; then
+        echo -e "${YELLOW}⚠ Could not generate Windows PowerShell hooks${NC}"
+        return 0
+    fi
+
+    if ! printf '%s\n' "$hooks_json" | grep -qE '"shell"[[:space:]]*:[[:space:]]*"powershell"'; then
+        echo -e "${YELLOW}⚠ Generated Windows hooks did not include PowerShell shell setting${NC}"
+        return 0
+    fi
+
+    local tmp_hooks="${hooks_path}.tmp.$$"
+    if printf '%s\n' "$hooks_json" > "$tmp_hooks" 2>/dev/null && mv "$tmp_hooks" "$hooks_path" 2>/dev/null; then
+        echo -e "${GREEN}✓${NC} Windows PowerShell hooks configured"
+        echo -e "${YELLOW}  Restart Claude Code to apply the Windows hook update.${NC}"
+    else
+        rm -f "$tmp_hooks" 2>/dev/null || true
+        echo -e "${YELLOW}⚠ Could not write Windows PowerShell hooks${NC}"
+    fi
+
+    return 0
 }
 
 # Cleanup temporary files
@@ -1514,6 +1587,7 @@ main() {
     if check_existing; then
         # Even if binary exists, ensure symlink is created
         create_symlink
+        configure_windows_native_hooks
 
         # Download utility binaries (sound-preview, list-devices)
         download_utilities
@@ -1551,6 +1625,12 @@ main() {
         echo ""
         echo -e "${YELLOW}Running in offline mode...${NC}"
 
+        if [ "$WINDOWS_NATIVE_HOOKS_NEED_UPDATE" = true ]; then
+            echo -e "${RED}✗ Existing Windows binary is too old for PowerShell hooks${NC}" >&2
+            echo -e "${YELLOW}Restore network access and rerun the installer to download a compatible binary.${NC}" >&2
+            exit 1
+        fi
+
         # Verify existing binary still works
         if ! verify_executable; then
             echo -e "${RED}✗ Existing binary is corrupted or incompatible${NC}" >&2
@@ -1560,6 +1640,7 @@ main() {
 
         # Ensure symlink exists
         create_symlink
+        configure_windows_native_hooks
 
         echo ""
         echo -e "${GREEN}========================================${NC}"
@@ -1614,6 +1695,7 @@ main() {
 
     # Create symlink for hooks to use
     create_symlink
+    configure_windows_native_hooks
 
     # Download utility binaries (sound-preview, list-devices)
     download_utilities

--- a/bin/install_e2e_test.sh
+++ b/bin/install_e2e_test.sh
@@ -10,6 +10,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INSTALL_SCRIPT="$SCRIPT_DIR/install.sh"
 MOCK_SERVER="$SCRIPT_DIR/mock_server.py"
 FIXTURES_DIR="$SCRIPT_DIR/test_fixtures"
@@ -652,6 +653,299 @@ test_force_removes_symlinks() {
         TESTS_PASSED=$((TESTS_PASSED + 1))
     fi
     TESTS_RUN=$((TESTS_RUN + 1))
+
+    cleanup_test_dir
+}
+
+test_windows_native_hooks_configured_existing_binary() {
+    echo -e "\n${CYAN}▶ test_windows_native_hooks_configured_existing_binary${NC}"
+    setup_test_dir
+
+    local plugin_root="$TEST_DIR/plugin"
+    local bin_dir="$plugin_root/bin"
+    local hooks_dir="$plugin_root/hooks"
+    local fake_path="$TEST_DIR/fakebin"
+
+    mkdir -p "$bin_dir" "$hooks_dir" "$fake_path"
+    printf '{"hooks":{}}\n' > "$hooks_dir/hooks.json"
+
+    cat > "$fake_path/uname" <<'UNAME_EOF'
+#!/bin/sh
+case "$1" in
+  -s) echo "MINGW64_NT-10.0" ;;
+  -m) echo "x86_64" ;;
+  *) echo "MINGW64_NT-10.0" ;;
+esac
+UNAME_EOF
+    chmod +x "$fake_path/uname"
+
+    cat > "$bin_dir/claude-notifications-windows-amd64.exe" <<'FAKE_EXE_EOF'
+#!/bin/sh
+if [ "$1" = "--version" ] || [ "$1" = "version" ]; then
+    echo "claude-notifications v1.38.0"
+    exit 0
+fi
+if [ "$1" = "windows-hooks" ]; then
+    exe=""
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--exe" ]; then
+            shift
+            exe="$1"
+        fi
+        shift
+    done
+    printf '{\n  "hooks": {\n    "Stop": [\n      {\n        "hooks": [\n          {\n            "type": "command",\n            "command": "$input | & \"%s\" handle-hook Stop",\n            "timeout": 30,\n            "shell": "powershell"\n          }\n        ]\n      }\n    ]\n  }\n}\n' "$exe"
+    exit 0
+fi
+exit 0
+FAKE_EXE_EOF
+    chmod +x "$bin_dir/claude-notifications-windows-amd64.exe"
+
+    touch "$bin_dir/sound-preview-windows-amd64.exe"
+    touch "$bin_dir/list-devices-windows-amd64.exe"
+    touch "$bin_dir/list-sounds-windows-amd64.exe"
+
+    local output exit_code
+    output=$(INSTALL_TARGET_DIR="$bin_dir" PATH="$fake_path:$PATH" bash "$INSTALL_SCRIPT" 2>&1)
+    exit_code=$?
+
+    assert_exit_code 0 $exit_code "Installer succeeds with existing Windows binary"
+    assert_contains "$output" "Windows PowerShell hooks configured" "Windows hooks configuration message shown"
+
+    local hooks_json
+    hooks_json=$(cat "$hooks_dir/hooks.json")
+    assert_contains "$hooks_json" '"shell"[[:space:]]*:[[:space:]]*"powershell"' "hooks.json uses PowerShell shell"
+    assert_contains "$hooks_json" 'handle-hook Stop' "hooks.json calls Stop handler"
+    assert_contains "$hooks_json" 'claude-notifications-windows-amd64\.exe' "hooks.json points at Windows exe"
+
+    cleanup_test_dir
+}
+
+test_windows_old_binary_forces_update_before_hooks() {
+    echo -e "\n${CYAN}▶ test_windows_old_binary_forces_update_before_hooks${NC}"
+    setup_test_dir
+
+    local plugin_root="$TEST_DIR/plugin"
+    local bin_dir="$plugin_root/bin"
+    local hooks_dir="$plugin_root/hooks"
+    local fake_path="$TEST_DIR/fakebin"
+
+    mkdir -p "$bin_dir" "$hooks_dir" "$fake_path"
+    printf '{"hooks":{}}\n' > "$hooks_dir/hooks.json"
+
+    cat > "$fake_path/uname" <<'UNAME_EOF'
+#!/bin/sh
+case "$1" in
+  -s) echo "MINGW64_NT-10.0" ;;
+  -m) echo "x86_64" ;;
+  *) echo "MINGW64_NT-10.0" ;;
+esac
+UNAME_EOF
+    chmod +x "$fake_path/uname"
+
+    cat > "$bin_dir/claude-notifications-windows-amd64.exe" <<'OLD_EXE_EOF'
+#!/bin/sh
+if [ "$1" = "--version" ] || [ "$1" = "version" ]; then
+    echo "claude-notifications v1.37.0"
+    exit 0
+fi
+echo "unknown command: $1" >&2
+exit 1
+OLD_EXE_EOF
+    chmod +x "$bin_dir/claude-notifications-windows-amd64.exe"
+
+    local output exit_code
+    set +e
+    output=$(INSTALL_TARGET_DIR="$bin_dir" PATH="$fake_path:$PATH" SKIP_CONNECTIVITY_CHECK=true \
+        RELEASE_URL="file:///no-such-claude-notifications-release" CHECKSUMS_URL="file:///no-such-claude-notifications-release/checksums.txt" \
+        run_with_timeout 15 bash "$INSTALL_SCRIPT" 2>&1)
+    exit_code=$?
+    set +e
+
+    assert_exit_code 1 $exit_code "Old Windows binary does not complete setup silently"
+    assert_contains "$output" "cannot generate PowerShell hooks" "Installer detects old binary without windows-hooks"
+    assert_contains "$output" "Updating claude-notifications-windows-amd64.exe before rewriting hooks" "Installer chooses update path"
+    assert_not_contains "$output" "Setup complete" "Installer does not report success with stale hooks"
+
+    cleanup_test_dir
+}
+
+test_windows_native_hooks_real_powershell_launch() {
+    echo -e "\n${CYAN}▶ test_windows_native_hooks_real_powershell_launch${NC}"
+
+    if ! is_windows; then
+        skip_test "Windows native PowerShell hook launch" "not on Windows"
+        return
+    fi
+
+    if ! command -v go >/dev/null 2>&1; then
+        skip_test "Windows native PowerShell hook launch" "go not available"
+        return
+    fi
+
+    local ps_bin=""
+    if command -v powershell.exe >/dev/null 2>&1; then
+        ps_bin="powershell.exe"
+    elif command -v pwsh >/dev/null 2>&1; then
+        ps_bin="pwsh"
+    else
+        skip_test "Windows native PowerShell hook launch" "PowerShell not available"
+        return
+    fi
+
+    setup_test_dir
+
+    local plugin_root="$TEST_DIR/plugin"
+    local bin_dir="$plugin_root/bin"
+    local hooks_dir="$plugin_root/hooks"
+    mkdir -p "$bin_dir" "$hooks_dir"
+    printf '{"hooks":{}}\n' > "$hooks_dir/hooks.json"
+
+    local exe_path="$bin_dir/claude-notifications-windows-amd64.exe"
+    if ! (cd "$REPO_ROOT" && go build -o "$exe_path" ./cmd/claude-notifications); then
+        fail_test "Build real Windows notification binary" "go build failed"
+        cleanup_test_dir
+        return
+    fi
+
+    touch "$bin_dir/sound-preview-windows-amd64.exe"
+    touch "$bin_dir/list-devices-windows-amd64.exe"
+    touch "$bin_dir/list-sounds-windows-amd64.exe"
+
+    local output exit_code
+    output=$(INSTALL_TARGET_DIR="$bin_dir" bash "$INSTALL_SCRIPT" 2>&1)
+    exit_code=$?
+
+    assert_exit_code 0 $exit_code "Installer succeeds with real Windows binary"
+    assert_contains "$output" "Windows PowerShell hooks configured" "Installer rewrites hooks for PowerShell"
+
+    local hooks_json
+    hooks_json=$(cat "$hooks_dir/hooks.json")
+    assert_contains "$hooks_json" '"shell"[[:space:]]*:[[:space:]]*"powershell"' "real hooks.json uses PowerShell shell"
+    assert_contains "$hooks_json" '\$OutputEncoding = \[System\.Text\.UTF8Encoding\]::new\(\$false\)' "real hooks.json sets PowerShell UTF-8 output encoding"
+    assert_contains "$hooks_json" 'handle-hook Stop' "real hooks.json contains Stop hook"
+
+    local exe_for_powershell="$exe_path"
+    if command -v cygpath >/dev/null 2>&1; then
+        exe_for_powershell="$(cygpath -w "$exe_path" 2>/dev/null || printf '%s' "$exe_path")"
+    fi
+
+    set +e
+    output=$(printf '{"session_id":"ci-win","transcript_path":"","cwd":""}\n' | \
+        "$ps_bin" -NoProfile -ExecutionPolicy Bypass -Command "\$OutputEncoding = [System.Text.UTF8Encoding]::new(\$false); \$input | & '$exe_for_powershell' handle-hook Stop" 2>&1)
+    exit_code=$?
+    set +e
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo "$output"
+    fi
+
+    assert_exit_code 0 $exit_code "Generated PowerShell hook command launches real exe"
+
+    cleanup_test_dir
+}
+
+test_windows_real_hook_schedules_lazy_update() {
+    echo -e "\n${CYAN}▶ test_windows_real_hook_schedules_lazy_update${NC}"
+
+    if ! is_windows; then
+        skip_test "Windows real hook schedules lazy update" "not on Windows"
+        return
+    fi
+
+    if ! command -v go >/dev/null 2>&1; then
+        skip_test "Windows real hook schedules lazy update" "go not available"
+        return
+    fi
+
+    local ps_bin=""
+    if command -v powershell.exe >/dev/null 2>&1; then
+        ps_bin="powershell.exe"
+    elif command -v pwsh >/dev/null 2>&1; then
+        ps_bin="pwsh"
+    else
+        skip_test "Windows real hook schedules lazy update" "PowerShell not available"
+        return
+    fi
+
+    setup_test_dir
+
+    local plugin_root="$TEST_DIR/plugin"
+    local bin_dir="$plugin_root/bin"
+    local manifest_dir="$plugin_root/.claude-plugin"
+    mkdir -p "$bin_dir" "$manifest_dir"
+    printf '{"version":"9.99.0"}\n' > "$manifest_dir/plugin.json"
+    cp "$INSTALL_SCRIPT" "$bin_dir/install.sh"
+
+    local exe_path="$bin_dir/claude-notifications-windows-amd64.exe"
+    if ! (cd "$REPO_ROOT" && go build -o "$exe_path" ./cmd/claude-notifications); then
+        fail_test "Build real Windows notification binary for lazy update" "go build failed"
+        cleanup_test_dir
+        return
+    fi
+
+    local fake_bash_go="$TEST_DIR/fake-bash.go"
+    local fake_bash="$TEST_DIR/fake-bash.exe"
+    local fake_bash_log="$TEST_DIR/fake-bash.log"
+    cat > "$fake_bash_go" <<'FAKE_BASH_GO_EOF'
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	logPath := os.Getenv("FAKE_BASH_LOG")
+	if logPath == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(logPath), 0755)
+	_ = os.WriteFile(logPath, []byte(strings.Join(os.Args[1:], "\n")), 0644)
+}
+FAKE_BASH_GO_EOF
+    if ! go build -o "$fake_bash" "$fake_bash_go"; then
+        fail_test "Build fake bash for lazy update" "go build failed"
+        cleanup_test_dir
+        return
+    fi
+
+    local exe_for_powershell="$exe_path"
+    local fake_bash_for_powershell="$fake_bash"
+    local fake_bash_log_for_powershell="$fake_bash_log"
+    if command -v cygpath >/dev/null 2>&1; then
+        exe_for_powershell="$(cygpath -w "$exe_path" 2>/dev/null || printf '%s' "$exe_path")"
+        fake_bash_for_powershell="$(cygpath -w "$fake_bash" 2>/dev/null || printf '%s' "$fake_bash")"
+        fake_bash_log_for_powershell="$(cygpath -w "$fake_bash_log" 2>/dev/null || printf '%s' "$fake_bash_log")"
+    fi
+
+    local output exit_code
+    set +e
+    output=$(printf '{"session_id":"ci-win","transcript_path":"","cwd":""}\n' | \
+        "$ps_bin" -NoProfile -ExecutionPolicy Bypass -Command "\$env:CLAUDE_NOTIFICATIONS_BASH = '$fake_bash_for_powershell'; \$env:FAKE_BASH_LOG = '$fake_bash_log_for_powershell'; \$env:CLAUDE_HOOK_JUDGE_MODE = 'true'; \$OutputEncoding = [System.Text.UTF8Encoding]::new(\$false); \$input | & '$exe_for_powershell' handle-hook Stop" 2>&1)
+    exit_code=$?
+    set +e
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo "$output"
+    fi
+    assert_exit_code 0 $exit_code "Real Windows hook exits successfully with plugin version mismatch"
+
+    local i=0
+    while [ $i -lt 80 ] && [ ! -f "$fake_bash_log" ]; do
+        sleep 0.1
+        i=$((i + 1))
+    done
+
+    assert_file_exists "$fake_bash_log" "Windows hook schedules lazy update through bash"
+    if [ -f "$fake_bash_log" ]; then
+        local fake_log
+        fake_log=$(cat "$fake_bash_log")
+        assert_contains "$fake_log" '^-lc$|^-l$' "Lazy update invokes bash login mode"
+        assert_contains "$fake_log" '^-lc$|^-c$' "Lazy update invokes bash command mode"
+        assert_contains "$fake_log" 'install\.sh.*--force' "Lazy update uses install.sh --force"
+    fi
 
     cleanup_test_dir
 }
@@ -1786,6 +2080,10 @@ main() {
         test_required_tools_curl_wget
         test_force_removes_binaries
         test_force_removes_symlinks
+        test_windows_native_hooks_configured_existing_binary
+        test_windows_old_binary_forces_update_before_hooks
+        test_windows_native_hooks_real_powershell_launch
+        test_windows_real_hook_schedules_lazy_update
         test_force_removes_apps_macos
     fi
 

--- a/cmd/claude-notifications/main.go
+++ b/cmd/claude-notifications/main.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/777genius/claude-notifications/internal/audio"
 	"github.com/777genius/claude-notifications/internal/errorhandler"
@@ -16,6 +19,12 @@ import (
 )
 
 const version = "1.38.0"
+const windowsLazyUpdateRetryAfter = time.Hour
+
+var (
+	currentGOOS               = runtime.GOOS
+	scheduleWindowsLazyUpdate = scheduleWindowsLazyUpdateImpl
+)
 
 func main() {
 	// Initialize global error handler with panic recovery
@@ -177,7 +186,7 @@ func parseWindowsHooksExecutable(args []string) (string, error) {
 func newPowerShellHook(exePath, hookName string) hookCommand {
 	return hookCommand{
 		Type:    "command",
-		Command: "$input | & " + powershellDoubleQuoted(exePath) + " handle-hook " + hookName,
+		Command: "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); $input | & " + powershellDoubleQuoted(exePath) + " handle-hook " + hookName,
 		Timeout: 30,
 		Shell:   "powershell",
 	}
@@ -198,6 +207,7 @@ func handleHook(hookEvent string) {
 
 	// Determine plugin root
 	pluginRoot := getPluginRoot()
+	maybeScheduleWindowsLazyUpdate(pluginRoot)
 
 	// Initialize logger
 	if _, err := logging.InitLogger(pluginRoot); err != nil {
@@ -218,6 +228,186 @@ func handleHook(hookEvent string) {
 		errorhandler.HandleCriticalError(err, "Failed to handle hook")
 		os.Exit(1)
 	}
+}
+
+type pluginManifest struct {
+	Version string `json:"version"`
+}
+
+func maybeScheduleWindowsLazyUpdate(pluginRoot string) {
+	if currentGOOS != "windows" {
+		return
+	}
+
+	pluginVersion := readPluginManifestVersion(pluginRoot)
+	if pluginVersion == "" || pluginVersion == version {
+		return
+	}
+
+	stampKey := version + "->" + pluginVersion
+	stampPath := windowsLazyUpdateStampPath(pluginRoot)
+	if windowsLazyUpdateRecentlyScheduled(stampPath, stampKey) {
+		return
+	}
+
+	stampWritten := writeWindowsLazyUpdateStamp(stampPath, stampKey) == nil
+	if err := scheduleWindowsLazyUpdate(pluginRoot); err != nil && stampWritten {
+		_ = os.Remove(stampPath)
+	}
+}
+
+func readPluginManifestVersion(pluginRoot string) string {
+	data, err := os.ReadFile(filepath.Join(pluginRoot, ".claude-plugin", "plugin.json"))
+	if err != nil {
+		return ""
+	}
+
+	var manifest pluginManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return ""
+	}
+	return manifest.Version
+}
+
+func windowsLazyUpdateStampPath(pluginRoot string) string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil || cacheDir == "" {
+		cacheDir = filepath.Join(pluginRoot, ".cache")
+	}
+	return filepath.Join(cacheDir, "claude-notifications-go", "windows-lazy-update-stamp")
+}
+
+func windowsLazyUpdateRecentlyScheduled(stampPath, stampKey string) bool {
+	info, err := os.Stat(stampPath)
+	if err != nil {
+		return false
+	}
+	if time.Since(info.ModTime()) > windowsLazyUpdateRetryAfter {
+		return false
+	}
+
+	data, err := os.ReadFile(stampPath)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == stampKey
+}
+
+func writeWindowsLazyUpdateStamp(stampPath, stampKey string) error {
+	if err := os.MkdirAll(filepath.Dir(stampPath), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(stampPath, []byte(stampKey+"\n"), 0o600)
+}
+
+func scheduleWindowsLazyUpdateImpl(pluginRoot string) error {
+	installScript := filepath.Join(pluginRoot, "bin", "install.sh")
+	if _, err := os.Stat(installScript); err != nil {
+		return err
+	}
+
+	powershellPath, err := findWindowsPowerShell()
+	if err != nil {
+		return err
+	}
+
+	bashPath, err := findWindowsBash()
+	if err != nil {
+		return err
+	}
+
+	targetDir := filepath.ToSlash(filepath.Join(pluginRoot, "bin"))
+	installScript = filepath.ToSlash(installScript)
+	shCommand := "INSTALL_TARGET_DIR=" + shellSingleQuoted(targetDir) + " " + shellSingleQuoted(installScript) + " --force"
+	psCommand := "$ErrorActionPreference = 'SilentlyContinue'; " +
+		"Start-Sleep -Milliseconds 750; " +
+		"for ($i = 0; $i -lt 6; $i++) { " +
+		"& " + powershellSingleQuoted(bashPath) + " -lc " + powershellSingleQuoted(shCommand) + " *> $null; " +
+		"if ($LASTEXITCODE -eq 0) { break }; " +
+		"Start-Sleep -Seconds 5 }"
+
+	cmd := exec.Command(powershellPath, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", psCommand)
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err == nil {
+		cmd.Stdin = devNull
+		cmd.Stdout = devNull
+		cmd.Stderr = devNull
+	}
+
+	if err := cmd.Start(); err != nil {
+		if devNull != nil {
+			_ = devNull.Close()
+		}
+		return err
+	}
+
+	if cmd.Process != nil {
+		_ = cmd.Process.Release()
+	}
+	if devNull != nil {
+		_ = devNull.Close()
+	}
+	return nil
+}
+
+func findWindowsPowerShell() (string, error) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil {
+		return path, nil
+	}
+
+	if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
+		candidate := filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("powershell.exe not found")
+}
+
+func findWindowsBash() (string, error) {
+	if override := os.Getenv("CLAUDE_NOTIFICATIONS_BASH"); override != "" {
+		if _, err := os.Stat(override); err == nil {
+			return override, nil
+		}
+		return "", fmt.Errorf("CLAUDE_NOTIFICATIONS_BASH not found: %s", override)
+	}
+
+	for _, name := range []string{"bash.exe", "bash"} {
+		if path, err := exec.LookPath(name); err == nil {
+			return path, nil
+		}
+	}
+
+	for _, candidate := range windowsBashCandidates() {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("bash.exe not found")
+}
+
+func windowsBashCandidates() []string {
+	var candidates []string
+	for _, root := range []string{os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)"), os.Getenv("LOCALAPPDATA")} {
+		if root == "" {
+			continue
+		}
+		candidates = append(candidates,
+			filepath.Join(root, "Git", "bin", "bash.exe"),
+			filepath.Join(root, "Programs", "Git", "bin", "bash.exe"),
+		)
+	}
+	return candidates
+}
+
+func shellSingleQuoted(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func powershellSingleQuoted(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func getPluginRoot() string {

--- a/cmd/claude-notifications/main_test.go
+++ b/cmd/claude-notifications/main_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadPluginManifestVersion(t *testing.T) {
+	pluginRoot := t.TempDir()
+	manifestDir := filepath.Join(pluginRoot, ".claude-plugin")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), []byte(`{"version":"9.99.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readPluginManifestVersion(pluginRoot); got != "9.99.0" {
+		t.Fatalf("readPluginManifestVersion() = %q, want %q", got, "9.99.0")
+	}
+}
+
+func TestMaybeScheduleWindowsLazyUpdateOnMismatch(t *testing.T) {
+	pluginRoot := setupLazyUpdateTestPlugin(t, "9.99.0")
+	withIsolatedLazyUpdateGlobals(t)
+
+	var called int
+	var gotRoot string
+	scheduleWindowsLazyUpdate = func(root string) error {
+		called++
+		gotRoot = root
+		return nil
+	}
+
+	maybeScheduleWindowsLazyUpdate(pluginRoot)
+	maybeScheduleWindowsLazyUpdate(pluginRoot)
+
+	if called != 1 {
+		t.Fatalf("scheduleWindowsLazyUpdate called %d times, want 1", called)
+	}
+	if gotRoot != pluginRoot {
+		t.Fatalf("scheduleWindowsLazyUpdate root = %q, want %q", gotRoot, pluginRoot)
+	}
+}
+
+func TestMaybeScheduleWindowsLazyUpdateSkipsMatchingVersion(t *testing.T) {
+	pluginRoot := setupLazyUpdateTestPlugin(t, version)
+	withIsolatedLazyUpdateGlobals(t)
+
+	scheduleWindowsLazyUpdate = func(root string) error {
+		t.Fatalf("scheduleWindowsLazyUpdate called for matching version at %s", root)
+		return nil
+	}
+
+	maybeScheduleWindowsLazyUpdate(pluginRoot)
+}
+
+func TestMaybeScheduleWindowsLazyUpdateRetriesAfterScheduleFailure(t *testing.T) {
+	pluginRoot := setupLazyUpdateTestPlugin(t, "9.99.0")
+	withIsolatedLazyUpdateGlobals(t)
+
+	var called int
+	scheduleWindowsLazyUpdate = func(root string) error {
+		called++
+		return errors.New("boom")
+	}
+
+	maybeScheduleWindowsLazyUpdate(pluginRoot)
+	maybeScheduleWindowsLazyUpdate(pluginRoot)
+
+	if called != 2 {
+		t.Fatalf("scheduleWindowsLazyUpdate called %d times, want 2", called)
+	}
+}
+
+func TestLazyUpdateQuoting(t *testing.T) {
+	if got, want := shellSingleQuoted(`C:/Users/O'Brien/bin/install.sh`), `'C:/Users/O'"'"'Brien/bin/install.sh'`; got != want {
+		t.Fatalf("shellSingleQuoted() = %q, want %q", got, want)
+	}
+	if got, want := powershellSingleQuoted(`C:\Users\O'Brien\bash.exe`), `'C:\Users\O''Brien\bash.exe'`; got != want {
+		t.Fatalf("powershellSingleQuoted() = %q, want %q", got, want)
+	}
+}
+
+func TestNewPowerShellHookSetsUTF8OutputEncoding(t *testing.T) {
+	hook := newPowerShellHook(`C:\Tools\claude-notifications.exe`, "Stop")
+
+	for _, want := range []string{
+		"$OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+		`$input | & "C:\Tools\claude-notifications.exe" handle-hook Stop`,
+	} {
+		if !strings.Contains(hook.Command, want) {
+			t.Fatalf("newPowerShellHook command = %q, want substring %q", hook.Command, want)
+		}
+	}
+	if hook.Shell != "powershell" {
+		t.Fatalf("newPowerShellHook shell = %q, want powershell", hook.Shell)
+	}
+}
+
+func setupLazyUpdateTestPlugin(t *testing.T, pluginVersion string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	pluginRoot := filepath.Join(root, "plugin")
+	for _, dir := range []string{
+		filepath.Join(pluginRoot, ".claude-plugin"),
+		filepath.Join(pluginRoot, "bin"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manifest := []byte(`{"version":"` + pluginVersion + `"}`)
+	if err := os.WriteFile(filepath.Join(pluginRoot, ".claude-plugin", "plugin.json"), manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "bin", "install.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	return pluginRoot
+}
+
+func withIsolatedLazyUpdateGlobals(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, ".cache"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(root, "LocalAppData"))
+
+	oldGOOS := currentGOOS
+	oldSchedule := scheduleWindowsLazyUpdate
+	currentGOOS = "windows"
+
+	t.Cleanup(func() {
+		currentGOOS = oldGOOS
+		scheduleWindowsLazyUpdate = oldSchedule
+	})
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,25 +108,27 @@ The bundled plugin hook configuration uses `bin/hook-wrapper.sh`. On some Window
 
 Claude Code supports PowerShell command hooks on Windows via `"shell": "powershell"`, so the safer Windows workaround is to call the native `.exe` directly with an absolute path.
 
-### Fix (recommended)
+### Fix
 
-Generate a PowerShell hook configuration from the installed executable:
+Run the bootstrap installer or `/claude-notifications-go:init` again, then restart Claude Code. On Windows, the installer rewrites the plugin hook file to use PowerShell hooks with an absolute path to the native `.exe`, avoiding the Git Bash/shebang path.
+
+If you need to inspect or apply the configuration manually, generate a PowerShell hook configuration from the installed executable. Replace `<arch>` with `amd64` or `arm64`:
 
 ```powershell
-.\bin\claude-notifications-windows-amd64.exe windows-hooks
+.\bin\claude-notifications-windows-<arch>.exe windows-hooks
 ```
 
 If you downloaded the executable to a different location, pass it explicitly:
 
 ```powershell
-.\bin\claude-notifications-windows-amd64.exe windows-hooks --exe "C:\absolute\path\to\claude-notifications-windows-amd64.exe"
+.\bin\claude-notifications-windows-<arch>.exe windows-hooks --exe "C:\absolute\path\to\claude-notifications-windows-<arch>.exe"
 ```
 
-Copy the generated `"hooks"` object into `%USERPROFILE%\.claude\settings.json`. This command only prints JSON - it does not modify your settings file.
+To apply it manually, replace the installed plugin's `hooks/hooks.json` with the generated JSON and restart Claude Code. This command only prints JSON - it does not modify files.
 
 ### Manual fallback
 
-If you cannot run `windows-hooks`, add this block manually and replace `<absolute-path-to-plugin>` with the actual plugin install directory:
+If you cannot run `windows-hooks`, replace the installed plugin's `hooks/hooks.json` with this block and replace `<absolute-path-to-plugin>` with the actual plugin install directory:
 
 ```json
 {
@@ -137,7 +139,7 @@ If you cannot run `windows-hooks`, add this block manually and replace `<absolut
         "hooks": [
           {
             "type": "command",
-            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook PreToolUse",
+            "command": "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); $input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-<arch>.exe\" handle-hook PreToolUse",
             "timeout": 30,
             "shell": "powershell"
           }
@@ -150,7 +152,7 @@ If you cannot run `windows-hooks`, add this block manually and replace `<absolut
         "hooks": [
           {
             "type": "command",
-            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook Notification",
+            "command": "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); $input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-<arch>.exe\" handle-hook Notification",
             "timeout": 30,
             "shell": "powershell"
           }
@@ -162,7 +164,7 @@ If you cannot run `windows-hooks`, add this block manually and replace `<absolut
         "hooks": [
           {
             "type": "command",
-            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook Stop",
+            "command": "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); $input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-<arch>.exe\" handle-hook Stop",
             "timeout": 30,
             "shell": "powershell"
           }
@@ -174,7 +176,7 @@ If you cannot run `windows-hooks`, add this block manually and replace `<absolut
         "hooks": [
           {
             "type": "command",
-            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook SubagentStop",
+            "command": "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); $input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-<arch>.exe\" handle-hook SubagentStop",
             "timeout": 30,
             "shell": "powershell"
           }
@@ -186,7 +188,7 @@ If you cannot run `windows-hooks`, add this block manually and replace `<absolut
         "hooks": [
           {
             "type": "command",
-            "command": "$input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-amd64.exe\" handle-hook TeammateIdle",
+            "command": "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); $input | & \"<absolute-path-to-plugin>\\bin\\claude-notifications-windows-<arch>.exe\" handle-hook TeammateIdle",
             "timeout": 30,
             "shell": "powershell"
           }
@@ -207,7 +209,7 @@ If the log contains `beeep.Notify failed on windows: doc.LoadXml(tmpl)` but the 
 
 ### Symptom
 
-Bootstrap or `/claude-notifications-go:init` installs the plugin itself, but downloading `claude-notifications-windows-amd64.exe` fails with an empty or generic network error.
+Bootstrap or `/claude-notifications-go:init` installs the plugin itself, but downloading `claude-notifications-windows-<arch>.exe` fails with an empty or generic network error.
 
 ### Why it happens
 
@@ -222,4 +224,4 @@ Bootstrap or `/claude-notifications-go:init` installs the plugin itself, but dow
 1. If your company requires a proxy, make sure the terminal running Claude Code or bootstrap has `HTTPS_PROXY`, `HTTP_PROXY`, or `ALL_PROXY` configured.
 2. If your network inspects TLS traffic, ensure Git Bash `curl` trusts the corporate CA certificate.
 3. Retry from another network or from WSL to confirm whether the issue is network-specific.
-4. As a fallback, open the latest release page, download `claude-notifications-windows-amd64.exe`, place it into the plugin `bin` directory, and then re-run `/claude-notifications-go:init`.
+4. As a fallback, open the latest release page, download the matching `claude-notifications-windows-amd64.exe` or `claude-notifications-windows-arm64.exe`, place it into the plugin `bin` directory, and then re-run `/claude-notifications-go:init`.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,6 +1,8 @@
 package hooks
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -130,7 +132,7 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 	// Parse hook data
 	bench.Start("stdin.parse")
 	var hookData HookData
-	if err := json.NewDecoder(input).Decode(&hookData); err != nil {
+	if err := json.NewDecoder(skipUTF8BOM(input)).Decode(&hookData); err != nil {
 		return fmt.Errorf("failed to parse hook data: %w", err)
 	}
 	bench.Elapsed("stdin.parse")
@@ -484,6 +486,15 @@ func (h *Handler) handleTeammateIdle(hookData *HookData) error {
 
 	logging.Debug("=== Hook completed: TeammateIdle (team notification sent) ===")
 	return nil
+}
+
+func skipUTF8BOM(input io.Reader) io.Reader {
+	reader := bufio.NewReader(input)
+	prefix, err := reader.Peek(3)
+	if err == nil && bytes.Equal(prefix, []byte{0xEF, 0xBB, 0xBF}) {
+		_, _ = reader.Discard(3)
+	}
+	return reader
 }
 
 // handleStopEvent handles Stop/SubagentStop hooks.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -606,6 +606,16 @@ func TestHandler_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestHandler_ParsesJSONWithUTF8BOM(t *testing.T) {
+	cfg := &config.Config{}
+	handler, _, _ := newTestHandler(t, cfg)
+
+	input := "\xef\xbb\xbf" + `{"session_id":"bom-session","transcript_path":"","cwd":""}`
+	if err := handler.HandleHook("Stop", strings.NewReader(input)); err != nil {
+		t.Fatalf("expected UTF-8 BOM-prefixed JSON to parse, got %v", err)
+	}
+}
+
 func TestHandler_MissingTranscriptFile(t *testing.T) {
 	cfg := &config.Config{
 		Notifications: config.NotificationsConfig{


### PR DESCRIPTION
## Summary
- rewrite installed Windows hook definitions to call the native exe via PowerShell
- keep macOS/Linux hook behavior unchanged behind a Windows-only installer guard
- add Windows CI smoke coverage that builds the real exe and launches it through PowerShell

## Tests
- bash -n bin/install.sh
- bash -n bin/install_e2e_test.sh
- go test ./...
- bash bin/install_e2e_test.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows lazy-update scheduling for notification plugins and native PowerShell hook wiring.
  * Installer now configures Windows-native hooks and validates PowerShell presence.

* **Bug Fixes**
  * Installer rewrites plugin hooks to invoke native PowerShell with absolute paths on Windows.
  * Hook JSON parsing now tolerates UTF-8 BOM to avoid parsing errors.
  * Improved CI stability for async webhook tests.

* **Tests**
  * Added Windows-focused end-to-end and unit tests for hooks, lazy-update, quoting, and encoding.

* **Documentation**
  * Updated Windows troubleshooting with new fix and manual fallback steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->