### PR TITLE
fix(notifier): fall back to tmux pane tty when /dev/tty unavailable

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -622,10 +622,48 @@ func (n *Notifier) Close() error {
 
 // sendTerminalBell writes a BEL character to /dev/tty to trigger terminal
 // tab indicators (e.g. Ghostty tab highlight, tmux window bell flag).
+//
+// When the hook subprocess has no controlling tty (notably Claude Code hooks,
+// which detach from the parent terminal), /dev/tty open fails with ENXIO.
+// In that case we fall back to writing BEL into the tmux pane's tty directly,
+// using $TMUX_PANE to locate the pane and `tmux display-message` to resolve
+// its tty path. Tmux reads the BEL from the pty and sets the window's bell
+// flag, so tab indicators (window-status-bell-style) still light up.
 func sendTerminalBell() {
 	f, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err == nil {
+		defer f.Close()
+		_, _ = f.Write([]byte("\a"))
+		return
+	}
+	logging.Debug("Could not open /dev/tty for bell: %v", err)
+
+	sendTmuxPaneBell()
+}
+
+// sendTmuxPaneBell writes a BEL byte to the current tmux pane's tty as a
+// fallback path for environments without a controlling tty (e.g. Claude Code
+// hook subprocesses). No-op when not running under tmux.
+func sendTmuxPaneBell() {
+	paneID := os.Getenv("TMUX_PANE")
+	if os.Getenv("TMUX") == "" || paneID == "" {
+		return
+	}
+
+	out, err := execCommand("tmux", "display-message", "-p", "-t", paneID, "#{pane_tty}").Output()
 	if err != nil {
-		logging.Debug("Could not open /dev/tty for bell: %v", err)
+		logging.Debug("tmux display-message failed for bell fallback: %v", err)
+		return
+	}
+
+	paneTTY := strings.TrimSpace(string(out))
+	if paneTTY == "" {
+		return
+	}
+
+	f, err := os.OpenFile(paneTTY, os.O_WRONLY, 0)
+	if err != nil {
+		logging.Debug("Could not open tmux pane tty %s for bell: %v", paneTTY, err)
 		return
 	}
 	defer f.Close()

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -843,6 +843,9 @@ func TestHelperProcess(t *testing.T) {
 	if stderrText := os.Getenv("GO_HELPER_STDERR"); stderrText != "" {
 		_, _ = os.Stderr.WriteString(stderrText)
 	}
+	if stdoutText := os.Getenv("GO_HELPER_STDOUT"); stdoutText != "" {
+		_, _ = os.Stdout.WriteString(stdoutText)
+	}
 
 	exitCode, err := strconv.Atoi(os.Getenv("GO_HELPER_EXIT_CODE"))
 	if err != nil {
@@ -1074,6 +1077,125 @@ func TestSendTerminalBell_DoesNotPanic(t *testing.T) {
 	// In CI there is no /dev/tty so the open will fail silently;
 	// in a real terminal the BEL character is written.
 	sendTerminalBell()
+}
+
+func TestSendTmuxPaneBell_NoTmuxEnv_NoOp(t *testing.T) {
+	// Should silently no-op when TMUX env is not set, without invoking tmux.
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+
+	called := false
+	originalExecCommand := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		called = true
+		return exec.Command("true")
+	}
+	defer func() { execCommand = originalExecCommand }()
+
+	sendTmuxPaneBell()
+
+	if called {
+		t.Error("tmux should not be invoked when TMUX env is empty")
+	}
+}
+
+func TestSendTmuxPaneBell_NoPaneEnv_NoOp(t *testing.T) {
+	// Should silently no-op when TMUX_PANE is missing even if TMUX is set.
+	t.Setenv("TMUX", "/tmp/tmux-501/default,1,0")
+	t.Setenv("TMUX_PANE", "")
+
+	called := false
+	originalExecCommand := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		called = true
+		return exec.Command("true")
+	}
+	defer func() { execCommand = originalExecCommand }()
+
+	sendTmuxPaneBell()
+
+	if called {
+		t.Error("tmux should not be invoked when TMUX_PANE is empty")
+	}
+}
+
+func TestSendTmuxPaneBell_WritesBELToPaneTTY(t *testing.T) {
+	// Create a temp file that stands in for the pane tty. Writing BEL into it
+	// should succeed and produce a single 0x07 byte.
+	tmpDir := t.TempDir()
+	fakePaneTTY := filepath.Join(tmpDir, "fake-pane-tty")
+	if err := os.WriteFile(fakePaneTTY, nil, 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	t.Setenv("TMUX", "/tmp/tmux-501/default,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+
+	var capturedArgs []string
+	originalExecCommand := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		capturedArgs = append([]string{name}, args...)
+		cmdArgs := []string{"-test.run=TestHelperProcess", "--", name}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.Command(os.Args[0], cmdArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			"GO_HELPER_STDOUT="+fakePaneTTY+"\n",
+			"GO_HELPER_EXIT_CODE=0",
+		)
+		return cmd
+	}
+	defer func() { execCommand = originalExecCommand }()
+
+	sendTmuxPaneBell()
+
+	// Verify the underlying tmux call used the expected arguments.
+	wantArgs := []string{"tmux", "display-message", "-p", "-t", "%42", "#{pane_tty}"}
+	if !equalStringSlices(capturedArgs, wantArgs) {
+		t.Errorf("tmux invocation mismatch:\n  got:  %v\n  want: %v", capturedArgs, wantArgs)
+	}
+
+	// Verify BEL was written to the pane tty.
+	contents, err := os.ReadFile(fakePaneTTY)
+	if err != nil {
+		t.Fatalf("read fake pane tty: %v", err)
+	}
+	if string(contents) != "\a" {
+		t.Errorf("expected BEL byte (0x07) in pane tty, got: %q (% x)", contents, contents)
+	}
+}
+
+func TestSendTmuxPaneBell_TmuxFailureDoesNotPanic(t *testing.T) {
+	// When tmux exits non-zero, the fallback should log and return cleanly.
+	t.Setenv("TMUX", "/tmp/tmux-501/default,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+
+	originalExecCommand := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestHelperProcess", "--", name}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.Command(os.Args[0], cmdArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			"GO_HELPER_EXIT_CODE=1",
+		)
+		return cmd
+	}
+	defer func() { execCommand = originalExecCommand }()
+
+	sendTmuxPaneBell()
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestSendDesktop_CallsBell(t *testing.T) {


### PR DESCRIPTION
## Summary

Claude Code spawns hook subprocesses without a controlling tty. Inside such a process, `os.OpenFile(\"/dev/tty\", ...)` fails with `ENXIO` (`device not configured`), so `sendTerminalBell` silently drops the BEL. Tmux never receives the bell byte, the window's `bell-flag` is never set, and `window-status-bell-style` indicators (tab \"shading\") stay dark when a task completes inside tmux.

This adds a fallback: when `/dev/tty` is unreachable and we detect we're running under tmux (`$TMUX` + `$TMUX_PANE` set), resolve the current pane's tty with `tmux display-message -p '#{pane_tty}'` and write BEL there directly. Tmux reads the byte from the pty as usual, so `monitor-bell` / `window-status-bell-style` work as expected.

Non-tmux behavior is unchanged — the new code path is only entered when the original `/dev/tty` open fails.

## Reproduction (before this patch)

Inside a hook-like context (no controlling tty), the existing call fails:

\`\`\`
\$ printf '\\007' > /dev/tty
zsh: device not configured: /dev/tty
\$ tmux list-windows -F '#I bell=#{window_bell_flag}'
… bell=0 everywhere …
\`\`\`

After the patch, the fallback resolves `pane_tty` (e.g. `/dev/ttys042`) and writes BEL there, which tmux picks up and reflects in the status bar.

## Test plan

- [x] `go fmt ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/notifier/` — all bell-related tests pass, including 4 new ones:
  - `TestSendTmuxPaneBell_NoTmuxEnv_NoOp`
  - `TestSendTmuxPaneBell_NoPaneEnv_NoOp`
  - `TestSendTmuxPaneBell_WritesBELToPaneTTY` (verifies tmux invocation args and BEL byte written)
  - `TestSendTmuxPaneBell_TmuxFailureDoesNotPanic`
- [x] Existing `TestSendTerminalBell_DoesNotPanic` still passes
- [x] Full repo test run passes (4 pre-existing failures unrelated to this change — those tests assume no real tmux server is running)
- [x] Manual verification: ran the fix path inside tmux from a no-tty subprocess; confirmed the target tmux window's `bell=1` flag flips and the configured `window-status-bell-style` highlights the tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal notification system with enhanced fallback mechanisms. Added better support for tmux environments to ensure notifications work reliably across different terminal configurations.

* **Tests**
  * Added comprehensive test coverage for terminal notifications, including scenarios for tmux sessions and various environment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/claude-notifications-go/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->