### PR TITLE
fix: use correct Linux WM class for GNOME activate-window-by-title

### DIFF
--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -211,9 +211,32 @@ func activateWindowTitleWithXdotool(windowTitle string) error {
 // TryActivateWindowByTitle uses the activate-window-by-title GNOME extension.
 // https://extensions.gnome.org/extension/5021/activate-window-by-title/
 // This method does NOT require unsafe_mode and works on GNOME 42+.
+//
+// It tries activateByWmClass first (reliable for Wayland-native terminals whose
+// WM class is a reverse-domain app ID, e.g. com.mitchellh.ghostty), then falls
+// back to activateBySubstring on the window title.
 func TryActivateWindowByTitle(terminalName, folderName string) error {
-	searchTerm := GetSearchTermWithFolder(terminalName, folderName)
+	// Try activateByWmClass first — more reliable than title substring search
+	// for Wayland-native terminals that use reverse-domain app IDs as WM class.
+	wmClass := GetGnomeWmClass(terminalName)
+	if wmClass != "" {
+		cmd := exec.Command("busctl", "--user", "call",
+			"org.gnome.Shell",
+			"/de/lucaswerkmeister/ActivateWindowByTitle",
+			"de.lucaswerkmeister.ActivateWindowByTitle",
+			"activateByWmClass", "s", wmClass,
+		)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			outputStr := strings.TrimSpace(string(output))
+			if strings.Contains(outputStr, "true") {
+				return nil
+			}
+		}
+	}
 
+	// Fall back to substring title search.
+	searchTerm := GetSearchTermWithFolder(terminalName, folderName)
 	cmd := exec.Command("busctl", "--user", "call",
 		"org.gnome.Shell",
 		"/de/lucaswerkmeister/ActivateWindowByTitle",

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -104,9 +104,43 @@ func getClaudeNotificationsDesktopEntryPath() string {
 	return dataHome + "/applications/" + claudeNotificationsDesktopEntryID + ".desktop"
 }
 
+// GetGnomeWmClass returns the WM_CLASS used by the activate-window-by-title
+// GNOME Shell extension for activateByWmClass calls.
+// For Wayland-native apps this is the app_id in reverse-domain format.
+func GetGnomeWmClass(terminalName string) string {
+	switch strings.ToLower(terminalName) {
+	case "ghostty":
+		return "com.mitchellh.ghostty"
+	case "wezterm":
+		return "org.wezfurlong.wezterm"
+	case "code", "vscode", "visual studio code":
+		return "code"
+	case "alacritty":
+		return "Alacritty"
+	case "kitty":
+		return "kitty"
+	case "gnome-terminal":
+		return "org.gnome.Terminal"
+	case "konsole":
+		return "org.kde.konsole"
+	case "tilix":
+		return "com.gexperts.Tilix"
+	case "terminator":
+		return "Terminator"
+	case "xfce4-terminal":
+		return "Xfce4-terminal"
+	case "mate-terminal":
+		return "Mate-terminal"
+	default:
+		return terminalName
+	}
+}
+
 // GetWlrctlAppID returns the wlroots app_id for a terminal name.
 func GetWlrctlAppID(terminalName string) string {
 	switch strings.ToLower(terminalName) {
+	case "ghostty":
+		return "com.mitchellh.ghostty"
 	case "code", "vscode", "visual studio code":
 		return "code"
 	case "alacritty":


### PR DESCRIPTION
## Problem

Click-to-focus fails on GNOME Wayland for Ghostty and WezTerm (and likely other Wayland-native terminals).

`TryActivateWindowByTitle` calls `activateBySubstring` with the terminal display name (`"ghostty"`, `"WezTerm"`), but Wayland-native terminals register with their reverse-domain app ID as WM class (`com.mitchellh.ghostty`, `org.wezfurlong.wezterm`). The extension never finds the window and returns `false`.

Confirmed via manual `gdbus call`:
```
activateByWmClass('ghostty')            → false
activateByWmClass('com.mitchellh.ghostty') → true

activateByWmClass('WezTerm')            → false
activateByWmClass('org.wezfurlong.wezterm') → true
```

## Fix

- Add `GetGnomeWmClass()` that maps terminal names to their actual Linux WM class (reverse-domain app ID for Wayland-native terminals)
- Update `TryActivateWindowByTitle` to try `activateByWmClass` first, then fall back to `activateBySubstring`
- Add `ghostty → com.mitchellh.ghostty` to `GetWlrctlAppID`

## Test

Tested on Ubuntu 26.04 / GNOME Shell 50 / Wayland with Ghostty and WezTerm. Daemon log now shows `Focus succeeded` instead of `all focus methods failed, last error: xdotool not installed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced window activation for GNOME environments with improved terminal emulator detection
  * Added support for additional terminal emulators including ghostty, wezterm, and VS Code variants for more reliable window focusing
  * Implemented fallback mechanism to ensure compatibility with terminal emulators using legacy activation methods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/claude-notifications-go/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->