### PR TITLE
fix(linux): use WM class for GNOME window focus + WezTerm tab-level focus

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -37,26 +37,31 @@ func NewClient() (*Client, error) {
 // SendNotification sends a notification request to the daemon.
 // focusFolder is the project folder name for window-specific focus (may be empty).
 // focusWindowID and focusWindowTitle are optional exact window hints captured in the hook process.
+// wezTermPaneID and wezTermSocket are WezTerm-specific hints for tab-level focus (may be empty).
 func (c *Client) SendNotification(
 	title,
 	body,
 	focusTarget,
 	focusFolder,
 	focusWindowID,
-	focusWindowTitle string,
+	focusWindowTitle,
+	wezTermPaneID,
+	wezTermSocket string,
 	timeout int,
 ) (*NotifyResponse, error) {
 	req := Request{
 		Type:    MessageTypeNotify,
 		Version: ProtocolVersion,
 		Notify: &NotifyRequest{
-			Title:            title,
-			Body:             body,
-			FocusTarget:      focusTarget,
-			FocusFolder:      focusFolder,
-			FocusWindowID:    focusWindowID,
-			FocusWindowTitle: focusWindowTitle,
-			Timeout:          timeout,
+			Title:              title,
+			Body:               body,
+			FocusTarget:        focusTarget,
+			FocusFolder:        focusFolder,
+			FocusWindowID:      focusWindowID,
+			FocusWindowTitle:   focusWindowTitle,
+			FocusWezTermPaneID: wezTermPaneID,
+			FocusWezTermSocket: wezTermSocket,
+			Timeout:            timeout,
 		},
 	}
 

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -35,17 +35,25 @@ func GetFocusMethods() []FocusMethod {
 // folderName is the project folder name used for title-based window search (may be empty).
 // It tries each method in order until one succeeds.
 func TryFocus(terminalName, folderName string) error {
-	return TryFocusWithHints(terminalName, folderName, "", "")
+	return TryFocusWithHints(terminalName, folderName, "", "", "", "")
 }
 
 // TryFocusWithWindowID preserves the previous API for callers that only have an exact X11 window ID.
 func TryFocusWithWindowID(terminalName, folderName, windowID string) error {
-	return TryFocusWithHints(terminalName, folderName, windowID, "")
+	return TryFocusWithHints(terminalName, folderName, windowID, "", "", "")
 }
 
 // TryFocusWithHints attempts exact focus using hook-time hints first, then falls back to
 // compositor-specific methods.
-func TryFocusWithHints(terminalName, folderName, windowID, windowTitle string) error {
+// wezTermPaneID and wezTermSocket enable tab-level focus for WezTerm.
+func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermPaneID, wezTermSocket string) error {
+	// WezTerm pane focus: highest priority — switches to the exact tab.
+	if strings.TrimSpace(wezTermPaneID) != "" {
+		if err := TryWezTermPane(wezTermPaneID, wezTermSocket); err == nil {
+			return nil
+		}
+	}
+
 	var exactErr error
 	if strings.TrimSpace(windowID) != "" {
 		if err := tryX11WindowID(windowID); err == nil {
@@ -82,6 +90,26 @@ func TryFocusWithHints(terminalName, folderName, windowID, windowTitle string) e
 		return exactErr
 	}
 	return fmt.Errorf("all focus methods failed, last error: %v", lastErr)
+}
+
+// TryWezTermPane activates a specific WezTerm pane by ID using the WezTerm CLI.
+// This switches to the exact tab/pane where Claude is running.
+func TryWezTermPane(paneID, socketPath string) error {
+	if _, err := exec.LookPath("wezterm"); err != nil {
+		return fmt.Errorf("wezterm not installed")
+	}
+
+	args := []string{"cli", "activate-pane", "--pane-id", paneID}
+	if strings.TrimSpace(socketPath) != "" {
+		args = append(args, "--unix-socket", socketPath)
+	}
+
+	cmd := exec.Command("wezterm", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("wezterm cli activate-pane failed: %w, output: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
 }
 
 func tryX11WindowID(windowID string) error {

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -57,7 +57,7 @@ func TryFocusWithWindowID(terminalName, folderName, windowID string) error {
 // If all window-level methods fail but a pane ID is available, TryWezTermPane is tried
 // as a last resort (activate-pane also raises the window on WezTerm).
 func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermPaneID, wezTermSocket string) error {
-	wezTermPaneID = strings.TrimSpace(wezTermPaneID)
+	wezTermPaneID, wezTermSocket = normalizeWezTermFocusHints(terminalName, wezTermPaneID, wezTermSocket)
 	windowFocused := false
 	var exactErr, lastErr error
 

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -5,6 +5,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -90,6 +91,20 @@ func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermP
 	}
 
 	if wezTermPaneID != "" {
+		// When multiple WezTerm windows are open, activateByWmClass may have raised
+		// the wrong one (both share the same WM class). Query the mux for the window
+		// title of the specific WezTerm window containing our pane, then use
+		// activateBySubstring to bring exactly that window to the front.
+		if wt := wezTermWindowTitle(wezTermPaneID, wezTermSocket); wt != "" {
+			cmd := exec.Command("busctl", "--user", "call",
+				"org.gnome.Shell",
+				"/de/lucaswerkmeister/ActivateWindowByTitle",
+				"de.lucaswerkmeister.ActivateWindowByTitle",
+				"activateBySubstring", "s", wt,
+			)
+			cmd.CombinedOutput() //nolint:errcheck // best-effort; non-GNOME systems will fail here
+		}
+
 		// Sleep briefly so GNOME's XDG Activation Token is processed before switching
 		// tabs — otherwise the token may restore the previously active tab and undo
 		// the pane switch.
@@ -121,6 +136,38 @@ func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermP
 		return fmt.Errorf("all focus methods failed, last error: %v", lastErr)
 	}
 	return nil
+}
+
+// wezTermWindowTitle queries the WezTerm mux for the window title of the window
+// containing paneID. Used to raise the exact WezTerm window when multiple instances
+// are open (they share the same WM class and can't be distinguished via activateByWmClass).
+// Returns empty string on any failure.
+func wezTermWindowTitle(paneID, socketPath string) string {
+	paneIDInt, err := strconv.Atoi(paneID)
+	if err != nil {
+		return ""
+	}
+	cmd := exec.Command("wezterm", "cli", "--no-auto-start", "list", "--format", "json")
+	if strings.TrimSpace(socketPath) != "" {
+		cmd.Env = append(os.Environ(), "WEZTERM_UNIX_SOCKET="+socketPath)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	var panes []struct {
+		PaneID      int    `json:"pane_id"`
+		WindowTitle string `json:"window_title"`
+	}
+	if err := json.Unmarshal(output, &panes); err != nil {
+		return ""
+	}
+	for _, p := range panes {
+		if p.PaneID == paneIDInt {
+			return p.WindowTitle
+		}
+	}
+	return ""
 }
 
 // TryWezTermPane activates a specific WezTerm pane by ID using the WezTerm CLI.

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -6,10 +6,12 @@ package daemon
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // FocusMethod represents a method for focusing a window
@@ -46,25 +48,23 @@ func TryFocusWithWindowID(terminalName, folderName, windowID string) error {
 // TryFocusWithHints attempts exact focus using hook-time hints first, then falls back to
 // compositor-specific methods.
 // wezTermPaneID and wezTermSocket enable tab-level focus for WezTerm.
+//
+// For WezTerm, we raise the window first via compositor methods, then switch the pane
+// with a short delay. This ordering matters: GNOME's XDG Activation Token is processed
+// after the window-level call, and it may re-show the previously active tab if the pane
+// switch runs first. Doing the pane switch last ensures it wins.
 func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermPaneID, wezTermSocket string) error {
-	// WezTerm pane focus: highest priority — switches to the exact tab.
-	if strings.TrimSpace(wezTermPaneID) != "" {
-		if err := TryWezTermPane(wezTermPaneID, wezTermSocket); err == nil {
-			return nil
-		}
-	}
-
 	var exactErr error
 	if strings.TrimSpace(windowID) != "" {
 		if err := tryX11WindowID(windowID); err == nil {
-			return nil
+			goto switchPane
 		} else {
 			exactErr = err
 		}
 	}
 	if strings.TrimSpace(windowTitle) != "" {
 		if err := tryWindowTitle(windowTitle); err == nil {
-			return nil
+			goto switchPane
 		} else if exactErr != nil {
 			exactErr = fmt.Errorf("%v; exact title focus failed: %v", exactErr, err)
 		} else {
@@ -72,39 +72,53 @@ func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermP
 		}
 	}
 
-	methods := GetFocusMethods()
-
-	var lastErr error
-	for _, method := range methods {
-		if err := method.Fn(terminalName, folderName); err != nil {
-			lastErr = err
-			continue
+	{
+		methods := GetFocusMethods()
+		var lastErr error
+		for _, method := range methods {
+			if err := method.Fn(terminalName, folderName); err != nil {
+				lastErr = err
+				continue
+			}
+			goto switchPane
 		}
-		return nil
+
+		if strings.TrimSpace(wezTermPaneID) == "" {
+			if exactErr != nil && lastErr != nil {
+				return fmt.Errorf("%v; fallback focus failed, last error: %v", exactErr, lastErr)
+			}
+			if exactErr != nil {
+				return exactErr
+			}
+			return fmt.Errorf("all focus methods failed, last error: %v", lastErr)
+		}
 	}
 
-	if exactErr != nil && lastErr != nil {
-		return fmt.Errorf("%v; fallback focus failed, last error: %v", exactErr, lastErr)
+switchPane:
+	// Switch WezTerm to the exact pane. Sleep briefly so GNOME's activation token
+	// is processed before we switch tabs — otherwise the token may restore the
+	// previously active tab and undo the pane switch.
+	if strings.TrimSpace(wezTermPaneID) != "" {
+		time.Sleep(150 * time.Millisecond)
+		_ = TryWezTermPane(wezTermPaneID, wezTermSocket)
 	}
-	if exactErr != nil {
-		return exactErr
-	}
-	return fmt.Errorf("all focus methods failed, last error: %v", lastErr)
+	return nil
 }
 
 // TryWezTermPane activates a specific WezTerm pane by ID using the WezTerm CLI.
 // This switches to the exact tab/pane where Claude is running.
+// socketPath is passed via WEZTERM_UNIX_SOCKET env var (the CLI has no --unix-socket flag).
 func TryWezTermPane(paneID, socketPath string) error {
 	if _, err := exec.LookPath("wezterm"); err != nil {
 		return fmt.Errorf("wezterm not installed")
 	}
 
-	args := []string{"cli", "activate-pane", "--pane-id", paneID}
+	// --no-auto-start: fail instead of spawning a new mux server when socket is wrong.
+	cmd := exec.Command("wezterm", "cli", "--no-auto-start", "activate-pane", "--pane-id", paneID)
 	if strings.TrimSpace(socketPath) != "" {
-		args = append(args, "--unix-socket", socketPath)
+		cmd.Env = append(os.Environ(), "WEZTERM_UNIX_SOCKET="+socketPath)
 	}
 
-	cmd := exec.Command("wezterm", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("wezterm cli activate-pane failed: %w, output: %s", err, strings.TrimSpace(string(output)))

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -211,9 +211,32 @@ func activateWindowTitleWithXdotool(windowTitle string) error {
 // TryActivateWindowByTitle uses the activate-window-by-title GNOME extension.
 // https://extensions.gnome.org/extension/5021/activate-window-by-title/
 // This method does NOT require unsafe_mode and works on GNOME 42+.
+//
+// It tries activateByWmClass first (reliable for Wayland-native terminals whose
+// WM class is a reverse-domain app ID, e.g. com.mitchellh.ghostty), then falls
+// back to activateBySubstring on the window title.
 func TryActivateWindowByTitle(terminalName, folderName string) error {
-	searchTerm := GetSearchTermWithFolder(terminalName, folderName)
+	// Try activateByWmClass first — more reliable than title substring search
+	// for Wayland-native terminals that use reverse-domain app IDs as WM class.
+	wmClass := GetGnomeWmClass(terminalName)
+	if wmClass != "" {
+		cmd := exec.Command("busctl", "--user", "call",
+			"org.gnome.Shell",
+			"/de/lucaswerkmeister/ActivateWindowByTitle",
+			"de.lucaswerkmeister.ActivateWindowByTitle",
+			"activateByWmClass", "s", wmClass,
+		)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			outputStr := strings.TrimSpace(string(output))
+			if strings.Contains(outputStr, "true") {
+				return nil
+			}
+		}
+	}
 
+	// Fall back to substring title search.
+	searchTerm := GetSearchTermWithFolder(terminalName, folderName)
 	cmd := exec.Command("busctl", "--user", "call",
 		"org.gnome.Shell",
 		"/de/lucaswerkmeister/ActivateWindowByTitle",

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -272,46 +272,59 @@ func activateWindowTitleWithXdotool(windowTitle string) error {
 // https://extensions.gnome.org/extension/5021/activate-window-by-title/
 // This method does NOT require unsafe_mode and works on GNOME 42+.
 //
-// It tries activateByWmClass first (reliable for Wayland-native terminals whose
-// WM class is a reverse-domain app ID, e.g. com.mitchellh.ghostty), then falls
-// back to activateBySubstring on the window title.
+// Search order:
+//  1. activateBySubstring with the folder-specific term, when available — ensures
+//     the correct project window is focused when multiple windows of the same app
+//     are open (e.g. two VS Code windows for different projects).
+//  2. activateByWmClass — reliable for Wayland-native terminals whose WM class is
+//     a reverse-domain app ID (e.g. com.mitchellh.ghostty, org.wezfurlong.wezterm)
+//     and whose window title does not contain the app name.
+//  3. activateBySubstring with the generic terminal name as a final fallback.
 func TryActivateWindowByTitle(terminalName, folderName string) error {
-	// Try activateByWmClass first — more reliable than title substring search
-	// for Wayland-native terminals that use reverse-domain app IDs as WM class.
-	wmClass := GetGnomeWmClass(terminalName)
-	if wmClass != "" {
+	gnomeActivate := func(method, arg string) bool {
 		cmd := exec.Command("busctl", "--user", "call",
 			"org.gnome.Shell",
 			"/de/lucaswerkmeister/ActivateWindowByTitle",
 			"de.lucaswerkmeister.ActivateWindowByTitle",
-			"activateByWmClass", "s", wmClass,
+			method, "s", arg,
 		)
 		output, err := cmd.CombinedOutput()
-		if err == nil {
-			outputStr := strings.TrimSpace(string(output))
-			if strings.Contains(outputStr, "true") {
-				return nil
-			}
+		return err == nil && strings.Contains(strings.TrimSpace(string(output)), "true")
+	}
+
+	// Step 1: folder-specific substring search (e.g. VS Code with a project folder).
+	// Only attempted when GetSearchTermWithFolder produces a different term than the
+	// plain terminal name — i.e. when the folder name is actually being used.
+	folderTerm := GetSearchTermWithFolder(terminalName, folderName)
+	if folderTerm != GetSearchTerm(terminalName) {
+		if gnomeActivate("activateBySubstring", folderTerm) {
+			return nil
 		}
 	}
 
-	// Fall back to substring title search.
-	searchTerm := GetSearchTermWithFolder(terminalName, folderName)
+	// Step 2: WM class match — most reliable for Wayland-native terminals.
+	if wmClass := GetGnomeWmClass(terminalName); wmClass != "" {
+		if gnomeActivate("activateByWmClass", wmClass) {
+			return nil
+		}
+	}
+
+	// Step 3: generic substring fallback.
+	genericTerm := GetSearchTerm(terminalName)
 	cmd := exec.Command("busctl", "--user", "call",
 		"org.gnome.Shell",
 		"/de/lucaswerkmeister/ActivateWindowByTitle",
 		"de.lucaswerkmeister.ActivateWindowByTitle",
-		"activateBySubstring", "s", searchTerm,
+		"activateBySubstring", "s", genericTerm,
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("activate-window-by-title extension not available: %w, output: %s", err, string(output))
 	}
-	// busctl can succeed (exit code 0) even when no window was activated.
-	// The extension returns a boolean; ensure we only treat "true" as success.
+	// busctl can succeed (exit 0) even when no window was activated; check the boolean.
 	outputStr := strings.TrimSpace(string(output))
 	if strings.Contains(outputStr, "false") || outputStr == "" {
-		return fmt.Errorf("activate-window-by-title: no window activated for %q (output: %s)", searchTerm, outputStr)
+		return fmt.Errorf("activate-window-by-title: no window activated for %q (output: %s)", genericTerm, outputStr)
 	}
 	return nil
 }

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -49,22 +49,28 @@ func TryFocusWithWindowID(terminalName, folderName, windowID string) error {
 // compositor-specific methods.
 // wezTermPaneID and wezTermSocket enable tab-level focus for WezTerm.
 //
-// For WezTerm, we raise the window first via compositor methods, then switch the pane
-// with a short delay. This ordering matters: GNOME's XDG Activation Token is processed
-// after the window-level call, and it may re-show the previously active tab if the pane
-// switch runs first. Doing the pane switch last ensures it wins.
+// For WezTerm, window-level focus runs first, then the pane switch runs after a short
+// delay. This ordering matters: GNOME's XDG Activation Token is processed asynchronously
+// after the window-level call and may restore the previously active tab if the pane
+// switch runs first. Running the pane switch last ensures it wins.
+// If all window-level methods fail but a pane ID is available, TryWezTermPane is tried
+// as a last resort (activate-pane also raises the window on WezTerm).
 func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermPaneID, wezTermSocket string) error {
-	var exactErr error
+	wezTermPaneID = strings.TrimSpace(wezTermPaneID)
+	windowFocused := false
+	var exactErr, lastErr error
+
 	if strings.TrimSpace(windowID) != "" {
 		if err := tryX11WindowID(windowID); err == nil {
-			goto switchPane
+			windowFocused = true
 		} else {
 			exactErr = err
 		}
 	}
-	if strings.TrimSpace(windowTitle) != "" {
+
+	if !windowFocused && strings.TrimSpace(windowTitle) != "" {
 		if err := tryWindowTitle(windowTitle); err == nil {
-			goto switchPane
+			windowFocused = true
 		} else if exactErr != nil {
 			exactErr = fmt.Errorf("%v; exact title focus failed: %v", exactErr, err)
 		} else {
@@ -72,35 +78,47 @@ func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermP
 		}
 	}
 
-	{
-		methods := GetFocusMethods()
-		var lastErr error
-		for _, method := range methods {
+	if !windowFocused {
+		for _, method := range GetFocusMethods() {
 			if err := method.Fn(terminalName, folderName); err != nil {
 				lastErr = err
 				continue
 			}
-			goto switchPane
-		}
-
-		if strings.TrimSpace(wezTermPaneID) == "" {
-			if exactErr != nil && lastErr != nil {
-				return fmt.Errorf("%v; fallback focus failed, last error: %v", exactErr, lastErr)
-			}
-			if exactErr != nil {
-				return exactErr
-			}
-			return fmt.Errorf("all focus methods failed, last error: %v", lastErr)
+			windowFocused = true
+			break
 		}
 	}
 
-switchPane:
-	// Switch WezTerm to the exact pane. Sleep briefly so GNOME's activation token
-	// is processed before we switch tabs — otherwise the token may restore the
-	// previously active tab and undo the pane switch.
-	if strings.TrimSpace(wezTermPaneID) != "" {
+	if wezTermPaneID != "" {
+		// Sleep briefly so GNOME's XDG Activation Token is processed before switching
+		// tabs — otherwise the token may restore the previously active tab and undo
+		// the pane switch.
 		time.Sleep(150 * time.Millisecond)
-		_ = TryWezTermPane(wezTermPaneID, wezTermSocket)
+		if err := TryWezTermPane(wezTermPaneID, wezTermSocket); err != nil && !windowFocused {
+			// Neither window-level focus nor pane switch succeeded.
+			if exactErr != nil && lastErr != nil {
+				return fmt.Errorf("%v; fallback focus failed, last error: %v; wezterm pane: %v", exactErr, lastErr, err)
+			}
+			if exactErr != nil {
+				return fmt.Errorf("%v; wezterm pane: %v", exactErr, err)
+			}
+			if lastErr != nil {
+				return fmt.Errorf("all focus methods failed, last error: %v; wezterm pane: %v", lastErr, err)
+			}
+			return fmt.Errorf("wezterm pane focus failed: %v", err)
+		}
+		// Pane switch succeeded, or window was already raised (pane switch is best-effort).
+		return nil
+	}
+
+	if !windowFocused {
+		if exactErr != nil && lastErr != nil {
+			return fmt.Errorf("%v; fallback focus failed, last error: %v", exactErr, lastErr)
+		}
+		if exactErr != nil {
+			return exactErr
+		}
+		return fmt.Errorf("all focus methods failed, last error: %v", lastErr)
 	}
 	return nil
 }

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -290,3 +290,13 @@ func getTerminatorWindowTitle() string {
 
 	return strings.TrimSpace(string(output))
 }
+
+// GetWezTermPaneID returns the WezTerm pane ID from the environment.
+func GetWezTermPaneID() string {
+	return strings.TrimSpace(os.Getenv("WEZTERM_PANE"))
+}
+
+// GetWezTermSocketPath returns the WezTerm Unix socket path from the environment.
+func GetWezTermSocketPath() string {
+	return strings.TrimSpace(os.Getenv("WEZTERM_UNIX_SOCKET"))
+}

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -300,3 +300,27 @@ func GetWezTermPaneID() string {
 func GetWezTermSocketPath() string {
 	return strings.TrimSpace(os.Getenv("WEZTERM_UNIX_SOCKET"))
 }
+
+// IsWezTermTerminalName reports whether terminalName identifies WezTerm.
+func IsWezTermTerminalName(terminalName string) bool {
+	switch strings.ToLower(strings.TrimSpace(terminalName)) {
+	case "wezterm", "wezterm-gui", "org.wezfurlong.wezterm", "org.wezfurlong.wezterm.desktop", "com.github.wez.wezterm":
+		return true
+	default:
+		return false
+	}
+}
+
+// GetWezTermFocusHints returns WezTerm-specific focus hints only when the
+// detected focus target is WezTerm. WEZTERM_* variables are often inherited by
+// GUI apps launched from WezTerm, so they must not be trusted for other targets.
+func GetWezTermFocusHints(terminalName string) (paneID, socketPath string) {
+	return normalizeWezTermFocusHints(terminalName, GetWezTermPaneID(), GetWezTermSocketPath())
+}
+
+func normalizeWezTermFocusHints(terminalName, paneID, socketPath string) (string, string) {
+	if !IsWezTermTerminalName(terminalName) {
+		return "", ""
+	}
+	return strings.TrimSpace(paneID), strings.TrimSpace(socketPath)
+}

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -104,9 +104,43 @@ func getClaudeNotificationsDesktopEntryPath() string {
 	return dataHome + "/applications/" + claudeNotificationsDesktopEntryID + ".desktop"
 }
 
+// GetGnomeWmClass returns the WM_CLASS used by the activate-window-by-title
+// GNOME Shell extension for activateByWmClass calls.
+// For Wayland-native apps this is the app_id in reverse-domain format.
+func GetGnomeWmClass(terminalName string) string {
+	switch strings.ToLower(terminalName) {
+	case "ghostty":
+		return "com.mitchellh.ghostty"
+	case "wezterm":
+		return "org.wezfurlong.wezterm"
+	case "code", "vscode", "visual studio code":
+		return "code"
+	case "alacritty":
+		return "Alacritty"
+	case "kitty":
+		return "kitty"
+	case "gnome-terminal":
+		return "org.gnome.Terminal"
+	case "konsole":
+		return "org.kde.konsole"
+	case "tilix":
+		return "com.gexperts.Tilix"
+	case "terminator":
+		return "Terminator"
+	case "xfce4-terminal":
+		return "Xfce4-terminal"
+	case "mate-terminal":
+		return "Mate-terminal"
+	default:
+		return terminalName
+	}
+}
+
 // GetWlrctlAppID returns the wlroots app_id for a terminal name.
 func GetWlrctlAppID(terminalName string) string {
 	switch strings.ToLower(terminalName) {
+	case "ghostty":
+		return "com.mitchellh.ghostty"
 	case "code", "vscode", "visual studio code":
 		return "code"
 	case "alacritty":

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -21,6 +21,8 @@ func saveTerminalEnv(t *testing.T) func() {
 		"XDG_SESSION_TYPE",
 		"XDG_CURRENT_DESKTOP",
 		"XDG_SESSION_DESKTOP",
+		"WEZTERM_PANE",
+		"WEZTERM_UNIX_SOCKET",
 	}
 	type envState struct {
 		value string
@@ -594,6 +596,66 @@ func TestGetExactWindowTitle_UnknownTerminal(t *testing.T) {
 
 	if got := GetExactWindowTitle("kitty"); got != "" {
 		t.Errorf("GetExactWindowTitle(unknown) = %q, want empty string", got)
+	}
+}
+
+func TestIsWezTermTerminalName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"wezterm", true},
+		{"WezTerm", true},
+		{"wezterm-gui", true},
+		{"org.wezfurlong.wezterm", true},
+		{"org.wezfurlong.wezterm.desktop", true},
+		{"com.github.wez.wezterm", true},
+		{"code", false},
+		{"kitty", false},
+		{"Terminal", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := IsWezTermTerminalName(tt.name); got != tt.want {
+			t.Errorf("IsWezTermTerminalName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestGetWezTermFocusHints_WezTermTarget(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	t.Setenv("WEZTERM_PANE", " 42 ")
+	t.Setenv("WEZTERM_UNIX_SOCKET", " /tmp/wezterm.sock ")
+
+	paneID, socketPath := GetWezTermFocusHints("WezTerm")
+	if paneID != "42" {
+		t.Errorf("paneID = %q, want %q", paneID, "42")
+	}
+	if socketPath != "/tmp/wezterm.sock" {
+		t.Errorf("socketPath = %q, want %q", socketPath, "/tmp/wezterm.sock")
+	}
+}
+
+func TestGetWezTermFocusHints_NonWezTermIgnoresInheritedEnv(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	t.Setenv("WEZTERM_PANE", "42")
+	t.Setenv("WEZTERM_UNIX_SOCKET", "/tmp/wezterm.sock")
+
+	paneID, socketPath := GetWezTermFocusHints("code")
+	if paneID != "" || socketPath != "" {
+		t.Errorf("GetWezTermFocusHints(code) = (%q, %q), want empty hints", paneID, socketPath)
+	}
+}
+
+func TestNormalizeWezTermFocusHints_NonWezTermIgnoresExplicitHints(t *testing.T) {
+	paneID, socketPath := normalizeWezTermFocusHints("kitty", "42", "/tmp/wezterm.sock")
+	if paneID != "" || socketPath != "" {
+		t.Errorf("normalizeWezTermFocusHints(kitty) = (%q, %q), want empty hints", paneID, socketPath)
 	}
 }
 

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -46,13 +46,15 @@ type Response struct {
 
 // NotifyRequest contains notification details sent to the daemon
 type NotifyRequest struct {
-	Title            string `json:"title"`
-	Body             string `json:"body"`
-	FocusTarget      string `json:"focus_target"`                 // Terminal identifier (empty = auto-detect)
-	FocusFolder      string `json:"focus_folder,omitempty"`       // Project folder name for window-specific focus
-	FocusWindowID    string `json:"focus_window_id,omitempty"`    // Exact X11 window ID captured in the hook process
-	FocusWindowTitle string `json:"focus_window_title,omitempty"` // Exact window title captured in the hook process when available
-	Timeout          int    `json:"timeout"`                      // Notification timeout in seconds
+	Title               string `json:"title"`
+	Body                string `json:"body"`
+	FocusTarget         string `json:"focus_target"`                   // Terminal identifier (empty = auto-detect)
+	FocusFolder         string `json:"focus_folder,omitempty"`         // Project folder name for window-specific focus
+	FocusWindowID       string `json:"focus_window_id,omitempty"`      // Exact X11 window ID captured in the hook process
+	FocusWindowTitle    string `json:"focus_window_title,omitempty"`   // Exact window title captured in the hook process when available
+	FocusWezTermPaneID  string `json:"focus_wezterm_pane_id,omitempty"`  // WezTerm pane ID ($WEZTERM_PANE)
+	FocusWezTermSocket  string `json:"focus_wezterm_socket,omitempty"`   // WezTerm unix socket ($WEZTERM_UNIX_SOCKET)
+	Timeout             int    `json:"timeout"`                        // Notification timeout in seconds
 }
 
 // NotifyResponse contains the result of a notification request

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -46,15 +46,15 @@ type Response struct {
 
 // NotifyRequest contains notification details sent to the daemon
 type NotifyRequest struct {
-	Title               string `json:"title"`
-	Body                string `json:"body"`
-	FocusTarget         string `json:"focus_target"`                   // Terminal identifier (empty = auto-detect)
-	FocusFolder         string `json:"focus_folder,omitempty"`         // Project folder name for window-specific focus
-	FocusWindowID       string `json:"focus_window_id,omitempty"`      // Exact X11 window ID captured in the hook process
-	FocusWindowTitle    string `json:"focus_window_title,omitempty"`   // Exact window title captured in the hook process when available
-	FocusWezTermPaneID  string `json:"focus_wezterm_pane_id,omitempty"`  // WezTerm pane ID ($WEZTERM_PANE)
-	FocusWezTermSocket  string `json:"focus_wezterm_socket,omitempty"`   // WezTerm unix socket ($WEZTERM_UNIX_SOCKET)
-	Timeout             int    `json:"timeout"`                        // Notification timeout in seconds
+	Title              string `json:"title"`
+	Body               string `json:"body"`
+	FocusTarget        string `json:"focus_target"`                    // Terminal identifier (empty = auto-detect)
+	FocusFolder        string `json:"focus_folder,omitempty"`          // Project folder name for window-specific focus
+	FocusWindowID      string `json:"focus_window_id,omitempty"`       // Exact X11 window ID captured in the hook process
+	FocusWindowTitle   string `json:"focus_window_title,omitempty"`    // Exact window title captured in the hook process when available
+	FocusWezTermPaneID string `json:"focus_wezterm_pane_id,omitempty"` // WezTerm pane ID ($WEZTERM_PANE)
+	FocusWezTermSocket string `json:"focus_wezterm_socket,omitempty"`  // WezTerm unix socket ($WEZTERM_UNIX_SOCKET)
+	Timeout            int    `json:"timeout"`                         // Notification timeout in seconds
 }
 
 // NotifyResponse contains the result of a notification request

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -21,10 +21,12 @@ import (
 
 // focusInfo holds the focus target and folder for a notification.
 type focusInfo struct {
-	target      string
-	folder      string
-	windowID    string
-	windowTitle string
+	target         string
+	folder         string
+	windowID       string
+	windowTitle    string
+	wezTermPaneID  string
+	wezTermSocket  string
 }
 
 // Server is the notification daemon server
@@ -280,15 +282,17 @@ func (s *Server) handleNotification(req *NotifyRequest) (*NotifyResponse, error)
 	// Store focus context
 	s.focusCtxMu.Lock()
 	s.focusCtx[id] = focusInfo{
-		target:      focusTarget,
-		folder:      req.FocusFolder,
-		windowID:    req.FocusWindowID,
-		windowTitle: req.FocusWindowTitle,
+		target:        focusTarget,
+		folder:        req.FocusFolder,
+		windowID:      req.FocusWindowID,
+		windowTitle:   req.FocusWindowTitle,
+		wezTermPaneID: req.FocusWezTermPaneID,
+		wezTermSocket: req.FocusWezTermSocket,
 	}
 	s.focusCtxMu.Unlock()
 
-	log.Printf("[INFO] Notification sent: ID=%d, focus_target=%s, focus_folder=%s, focus_window_id=%s, focus_window_title=%q",
-		id, focusTarget, req.FocusFolder, req.FocusWindowID, req.FocusWindowTitle)
+	log.Printf("[INFO] Notification sent: ID=%d, focus_target=%s, focus_folder=%s, focus_window_id=%s, focus_window_title=%q, wezterm_pane=%s",
+		id, focusTarget, req.FocusFolder, req.FocusWindowID, req.FocusWindowTitle, req.FocusWezTermPaneID)
 
 	return &NotifyResponse{
 		Success:        true,
@@ -312,6 +316,8 @@ func (s *Server) onActionInvoked(sig *notify.ActionInvokedSignal) {
 	focusFolder := info.folder
 	focusWindowID := info.windowID
 	focusWindowTitle := info.windowTitle
+	wezTermPaneID := info.wezTermPaneID
+	wezTermSocket := info.wezTermSocket
 
 	if !exists {
 		log.Printf("[WARN] No focus context for notification %d", sig.ID)
@@ -319,9 +325,9 @@ func (s *Server) onActionInvoked(sig *notify.ActionInvokedSignal) {
 	}
 
 	// Attempt to focus
-	log.Printf("[INFO] Attempting to focus: %s (folder: %s, window_id: %s, window_title: %q)",
-		focusTarget, focusFolder, focusWindowID, focusWindowTitle)
-	if err := TryFocusWithHints(focusTarget, focusFolder, focusWindowID, focusWindowTitle); err != nil {
+	log.Printf("[INFO] Attempting to focus: %s (folder: %s, window_id: %s, window_title: %q, wezterm_pane: %s)",
+		focusTarget, focusFolder, focusWindowID, focusWindowTitle, wezTermPaneID)
+	if err := TryFocusWithHints(focusTarget, focusFolder, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket); err != nil {
 		log.Printf("[ERROR] Focus failed: %v", err)
 	} else {
 		log.Printf("[INFO] Focus succeeded")

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -21,12 +21,12 @@ import (
 
 // focusInfo holds the focus target and folder for a notification.
 type focusInfo struct {
-	target         string
-	folder         string
-	windowID       string
-	windowTitle    string
-	wezTermPaneID  string
-	wezTermSocket  string
+	target        string
+	folder        string
+	windowID      string
+	windowTitle   string
+	wezTermPaneID string
+	wezTermSocket string
 }
 
 // Server is the notification daemon server

--- a/internal/notifier/terminal_linux.go
+++ b/internal/notifier/terminal_linux.go
@@ -93,9 +93,8 @@ func sendViaDaemon(title, body, cwd string) error {
 		focusWindowID = ""
 	}
 
-	// Capture WezTerm pane info for tab-level focus.
-	wezTermPaneID := daemon.GetWezTermPaneID()
-	wezTermSocket := daemon.GetWezTermSocketPath()
+	// Capture WezTerm pane info only when the focus target is actually WezTerm.
+	wezTermPaneID, wezTermSocket := daemon.GetWezTermFocusHints(focusTarget)
 
 	_, err = client.SendNotification(title, body, focusTarget, folderName, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket, 30)
 	return err

--- a/internal/notifier/terminal_linux.go
+++ b/internal/notifier/terminal_linux.go
@@ -93,7 +93,11 @@ func sendViaDaemon(title, body, cwd string) error {
 		focusWindowID = ""
 	}
 
-	_, err = client.SendNotification(title, body, focusTarget, folderName, focusWindowID, focusWindowTitle, 30)
+	// Capture WezTerm pane info for tab-level focus.
+	wezTermPaneID := daemon.GetWezTermPaneID()
+	wezTermSocket := daemon.GetWezTermSocketPath()
+
+	_, err = client.SendNotification(title, body, focusTarget, folderName, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket, 30)
 	return err
 }
 


### PR DESCRIPTION
## Problem

On Linux/GNOME/Wayland, clicking a notification often fails to bring the terminal window to the front, or brings the right window but lands on the wrong tab.

### Issue 1: \`activateBySubstring\` is unreliable for Wayland-native terminals

\`TryActivateWindowByTitle\` calls the [activate-window-by-title](https://extensions.gnome.org/extension/5021/activate-window-by-title/) GNOME extension's \`activateBySubstring\` method, passing the terminal's display name (e.g. \`"WezTerm"\`, \`"ghostty"\`).

\`activateBySubstring\` searches **window titles**, not WM class. Whether it works depends entirely on whether the terminal's window title happens to contain the app name — which is user-configurable and not guaranteed by default.

- **WezTerm**: the default window title shows the current pane's title (process name or working directory, e.g. \`~/cc\`), not \`"WezTerm"\`. Whether \`activateBySubstring("WezTerm")\` matches depends on the user's \`format_window_title\` config. Users who reported it working on Ubuntu 24.04 may have had a custom title format, or may have been on X11 where the detection path differs.
- **Ghostty**: never includes \`"Ghostty"\` in the window title by default — focus via \`activateBySubstring\` has always been unreliable for Ghostty.

The root cause is that Wayland-native terminals identify themselves via their **app\_id** (a reverse-domain string like \`org.wezfurlong.wezterm\` or \`com.mitchellh.ghostty\`), not their window title. The GNOME extension exposes \`activateByWmClass\` which matches this app\_id reliably regardless of window title configuration.

### Issue 2: No tab-level focus for WezTerm

Even when window focus succeeds, it raises the WezTerm window but leaves whichever tab was last active — not the specific tab where Claude is running.

## Fix

### WM class + folder-aware search order (all terminals)

\`TryActivateWindowByTitle\` now tries methods in this order:

1. **\`activateBySubstring\` with the folder-specific term** — when a project folder name is available and produces a more specific search term than the plain app name (e.g. VS Code with a project folder open). This ensures the correct window is focused when multiple instances of the same app are open for different projects.
2. **\`activateByWmClass\`** — matches the Wayland app\_id; reliable for Wayland-native terminals regardless of window title configuration.
3. **\`activateBySubstring\` with the generic terminal name** — original behaviour as a final fallback.

Also adds \`ghostty\` to the \`GetWlrctlAppID\` mapping (\`com.mitchellh.ghostty\`), which was missing.

### WezTerm tab-level focus

WezTerm exposes two environment variables in every pane:
- \`\$WEZTERM_PANE\` — unique integer ID of the current pane
- \`\$WEZTERM_UNIX_SOCKET\` — path to the mux server socket

The hook process captures these at notification time and passes them through the daemon protocol to the click handler. On notification click, after the window is raised, the handler calls:

\`\`\`
wezterm cli --no-auto-start activate-pane --pane-id <id>
\`\`\`

This switches WezTerm to the exact tab where Claude was running.

**Ordering matters**: the pane switch runs *after* window-level focus with a 150 ms delay. On GNOME/Wayland, the XDG Activation Token from \`activateByWmClass\` is processed asynchronously — if \`activate-pane\` runs first, GNOME's token processing fires afterwards and restores the previously active tab, undoing the switch.

If all window-level methods fail but a pane ID is present, \`TryWezTermPane\` is still attempted as a last resort — \`activate-pane\` also raises the WezTerm window, so it can serve as a full fallback for WezTerm users.

## Tested on

Ubuntu 26.04 / GNOME 50 / Wayland with Ghostty and WezTerm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications can include WezTerm pane and socket hints to target specific panes for focus
  * Improved focus activation flow on GNOME with smarter matching and WM-class activation
  * Added Ghostty app-id support for Wayland focus targeting

* **Tests**
  * New tests for WezTerm detection and focus-hint parsing/normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/777genius/claude-notifications-go/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->