### PR TITLE
fix(notifier): play sound even when the Windows toast call returns an error

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -489,16 +489,24 @@ func (n *Notifier) sendWithBeeep(title, message, appIcon, sound string) error {
 		beeep.AppName = originalAppName
 	}()
 
-	// Send notification using beeep with proper title and clean message
-	if err := beeep.Notify(title, message, appIcon); err != nil {
+	// Send notification using beeep with proper title and clean message.
+	err := beeep.Notify(title, message, appIcon)
+	if err != nil {
 		logging.Error("beeep.Notify failed on %s: %v (AppName=%q, title=%q)", runtime.GOOS, err, beeep.AppName, title)
-		return err
+	} else {
+		logging.Debug("Desktop notification sent via beeep: title=%s", title)
 	}
 
-	logging.Debug("Desktop notification sent via beeep: title=%s", title)
-
+	// Play the sound regardless of the toast outcome. The desktop toast and the
+	// audio cue are independent signals, and on Windows beeep.Notify routinely
+	// returns an error even though the toast was delivered: go-toast falls back
+	// to its PowerShell path when the WinRT COM call fails, but Push() still
+	// returns the (joined) COM error. Gating the sound on that error therefore
+	// drops the audio cue spuriously. See docs/troubleshooting.md, which already
+	// documents the "doc.LoadXml(tmpl)" error as a harmless false positive.
 	n.playSoundDetached(sound)
-	return nil
+
+	return err
 }
 
 // playSoundDetached spawns a detached child process to play the sound.


### PR DESCRIPTION
## Problem

`internal/notifier/notifier.go` `sendWithBeeep` returns early when `beeep.Notify` fails, **before** playing the sound:

```go
if err := beeep.Notify(title, message, appIcon); err != nil {
    logging.Error(...)
    return err            // sound never plays
}
n.playSoundDetached(sound)
```

On Windows this drops the audio cue frequently, because **`beeep.Notify` returns an error even when the toast is actually delivered**. `go-toast`'s `Notification.Push()` is invoked with `wintoast.PowershellFallback`; when the WinRT COM path (`RoInitialize` + `XmlDocument.LoadXml`) fails, it runs the PowerShell fallback — which shows the toast — but then returns `errors.Join(comErr, pushPowershell(...))`, i.e. the COM error is still returned even though the toast appeared.

`docs/troubleshooting.md` already documents this exact case: *"If the log contains `beeep.Notify failed on windows: doc.LoadXml(tmpl)` but the toast still appears, treat it as a harmless Windows notifier false positive."*

Net effect: on Windows the **toast shows but the sound is dropped** ~half the time, because the (often spurious) toast error short-circuits sound playback.

## Fix

Treat the toast and the sound as independent signals — log the toast error but **always** attempt `playSoundDetached`, then return the error for callers that still want to log it.

```go
err := beeep.Notify(title, message, appIcon)
if err != nil {
    logging.Error(...)
} else {
    logging.Debug(...)
}
n.playSoundDetached(sound) // independent of the toast outcome
return err
```

## Notes

- No behaviour change on the success path.
- The *underlying* intermittent COM failure (the spurious `doc.LoadXml` error itself) is addressed in a companion PR that pins the OS thread around the notify call so go-toast's WinRT calls don't migrate to an uninitialised-apartment thread. This PR is independent and makes the audio cue robust regardless of that.
- Verified locally on Windows 11 (Go 1.26, mingw-w64): `go build ./...`, `go vet ./...`, and `gofmt` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification audio cue behavior. The notification sound now plays reliably regardless of whether the toast notification succeeds or fails, ensuring consistent audio feedback in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->