### PR TITLE
fix(focus): detect Konsole via KONSOLE_* env (no TERM_PROGRAM)

### DIFF
--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -252,6 +252,11 @@ func GetTerminalName() string {
 		return "terminator"
 	}
 
+	// Check Konsole (does not set TERM_PROGRAM, but sets KONSOLE_* vars)
+	if os.Getenv("KONSOLE_VERSION") != "" || os.Getenv("KONSOLE_DBUS_SESSION") != "" {
+		return "konsole"
+	}
+
 	// Fallback to generic terminal
 	return "Terminal"
 }

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -17,6 +17,8 @@ func saveTerminalEnv(t *testing.T) func() {
 		"GNOME_TERMINAL_SCREEN",
 		"GNOME_TERMINAL_SERVICE",
 		"TERMINATOR_UUID",
+		"KONSOLE_VERSION",
+		"KONSOLE_DBUS_SESSION",
 		"WINDOWID",
 		"XDG_SESSION_TYPE",
 		"XDG_CURRENT_DESKTOP",
@@ -565,6 +567,44 @@ func TestGetTerminalName_TermProgramOverridesTerminatorUUID(t *testing.T) {
 	result := GetTerminalName()
 	if result != "alacritty" {
 		t.Errorf("GetTerminalName() with TERM_PROGRAM+TERMINATOR_UUID = %q, want %q", result, "alacritty")
+	}
+}
+
+func TestGetTerminalName_KonsoleVersion(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("KONSOLE_VERSION", "230804")
+
+	result := GetTerminalName()
+	if result != "konsole" {
+		t.Errorf("GetTerminalName() with KONSOLE_VERSION = %q, want %q", result, "konsole")
+	}
+}
+
+func TestGetTerminalName_KonsoleDBusSession(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("KONSOLE_DBUS_SESSION", "/Sessions/1")
+
+	result := GetTerminalName()
+	if result != "konsole" {
+		t.Errorf("GetTerminalName() with KONSOLE_DBUS_SESSION = %q, want %q", result, "konsole")
+	}
+}
+
+func TestGetTerminalName_TermProgramOverridesKonsole(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	// TERM_PROGRAM should take priority over KONSOLE_* vars
+	os.Setenv("TERM_PROGRAM", "ghostty")
+	os.Setenv("KONSOLE_VERSION", "230804")
+
+	result := GetTerminalName()
+	if result != "ghostty" {
+		t.Errorf("GetTerminalName() with TERM_PROGRAM+KONSOLE_VERSION = %q, want %q", result, "ghostty")
 	}
 }
 


### PR DESCRIPTION
## 问题

在 KDE Plasma (Wayland) 下，使用 Konsole 运行 Claude Code 时，点击桌面通知无法拉起 Konsole 窗口；同环境下 ghostty 等终端正常。

## 根因

`internal/daemon/mappings.go` 的 `GetTerminalName()` 终端检测链为：

```
TERM_PROGRAM → VSCode → gnome-terminal → terminator → 兜底返回 "Terminal"
```

Konsole 不设置 `TERM_PROGRAM`，因此走到兜底返回了 `"Terminal"`。后续 `TryKdotool()` 调用 `GetKdotoolClass("Terminal")`，default 返回 `"terminal"`，于是执行 `kdotool search --class terminal` —— 搜不到任何窗口（正确的应是 `--class konsole`），激活失败且无后备方法兜底。

ghostty 设置了 `TERM_PROGRAM=ghostty` 被正确识别，所以正常。映射表里 `konsole` 的 class/app_id 等条目本就齐全，只缺检测分支。

## 修复

在 `GetTerminalName()` 中，terminator 检测之后、兜底 `return "Terminal"` 之前，新增 Konsole 检测（通过 `KONSOLE_VERSION` / `KONSOLE_DBUS_SESSION`，Konsole 总会设置这两个变量之一）。

## 验证

KDE Wayland + Konsole 环境下：

- 修复前：`kdotool search --class terminal` → 空，点击通知无反应
- 修复后：识别为 konsole，`kdotool search --class konsole` → 命中窗口 id，点击通知成功激活

新增 `GetTerminalName()` 测试：两个 `KONSOLE_*` 变量都能识别为 `konsole`，且 `TERM_PROGRAM` 仍优先。`go build ./...` 与相关测试全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added detection for Konsole terminal emulator. The system now properly identifies when running in Konsole.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->