### PR TITLE
fix(hooks): detect subagent stops by event, not transcript_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Edit the config file directly:
     "suppressQuestionAfterTaskCompleteSeconds": 12,
     "suppressQuestionAfterAnyNotificationSeconds": 7,
     "notifyOnSubagentStop": false,
+    "suppressForSubagents": true,
     "notifyOnTextResponse": true,
     "respectJudgeMode": true,
     "suppressFilters": [
@@ -269,7 +270,8 @@ Edit the config file directly:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `notifyOnSubagentStop` | `false` | Send notifications when subagents (Task tool) complete |
+| `notifyOnSubagentStop` | `false` | Send notifications when subagents (Task tool) complete. Has no effect unless `suppressForSubagents` is also set to `false`. |
+| `suppressForSubagents` | `true` | Suppress subagent (`SubagentStop`) notifications, plus any `Stop` notification whose transcript is a subagent/teammate transcript. Detection uses the hook event for `SubagentStop` (Claude Code passes the parent session `transcript_path` to that hook, so a path check alone can't identify it). Set to `false` together with `notifyOnSubagentStop: true` to get a notification each time a subagent finishes. |
 | `notifyOnTextResponse` | `true` | Send notifications for text-only responses (no tool usage) |
 | `respectJudgeMode` | `true` | Honor `CLAUDE_HOOK_JUDGE_MODE=true` env var to suppress notifications |
 | `suppressQuestionAfterTaskCompleteSeconds` | `12` | Suppress question notifications for N seconds after task complete |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,8 @@ type NotificationsConfig struct {
 	Webhook                                     WebhookConfig    `json:"webhook"`
 	SuppressQuestionAfterTaskCompleteSeconds    *int             `json:"suppressQuestionAfterTaskCompleteSeconds"`
 	SuppressQuestionAfterAnyNotificationSeconds *int             `json:"suppressQuestionAfterAnyNotificationSeconds"`
-	NotifyOnSubagentStop                        bool             `json:"notifyOnSubagentStop"`      // Send notifications when subagents (Task tool) complete, default: false
-	SuppressForSubagents                        *bool            `json:"suppressForSubagents"`      // Suppress notifications when transcript_path contains /subagents/, default: true
+	NotifyOnSubagentStop                        bool             `json:"notifyOnSubagentStop"`      // Send notifications when subagents (Task tool) complete, default: false. Requires suppressForSubagents=false to take effect.
+	SuppressForSubagents                        *bool            `json:"suppressForSubagents"`      // Suppress subagent (SubagentStop) notifications, and Stop notifications whose transcript_path is a subagent/teammate transcript; default: true. Overrides notifyOnSubagentStop.
 	NotifyOnTextResponse                        *bool            `json:"notifyOnTextResponse"`      // Send notifications for text-only responses (no tools), default: true
 	RespectJudgeMode                            *bool            `json:"respectJudgeMode"`          // Honor CLAUDE_HOOK_JUDGE_MODE=true env var to suppress notifications, default: true
 	SuppressFilters                             []SuppressFilter `json:"suppressFilters,omitempty"` // Rules for suppressing notifications by status/branch/folder

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -184,7 +184,11 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 			return err
 		}
 	case "Stop":
-		// Check if this is a subagent transcript and should be suppressed
+		// A Stop event is the MAIN agent finishing, so suppress only when its
+		// transcript_path actually points at a subagent/teammate transcript
+		// (.../subagents/...). Note: on current Claude Code the Stop hook receives
+		// the parent session transcript, so this rarely matches — kept as a
+		// forward-compatible guard for transcripts that are routed differently.
 		if h.cfg.ShouldSuppressForSubagents() && isSubagentTranscript(hookData.TranscriptPath) {
 			logging.Debug("Stop: subagent transcript detected (%s), suppressing (config: suppressForSubagents)", hookData.TranscriptPath)
 			return nil
@@ -238,18 +242,23 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 		// State files have TTL and will be cleaned up automatically
 		defer h.cleanupOldLocks()
 	case "SubagentStop":
-		// Check config: should we suppress subagent notifications?
-		// First check path-based suppression (covers subagents and teammates)
-		if h.cfg.ShouldSuppressForSubagents() && isSubagentTranscript(hookData.TranscriptPath) {
-			logging.Debug("SubagentStop: subagent transcript detected (%s), suppressing (config: suppressForSubagents)", hookData.TranscriptPath)
+		// A SubagentStop event always denotes a subagent (Task tool) finishing,
+		// so the event type itself — not the transcript path — is the reliable
+		// subagent signal. Claude Code passes the PARENT session transcript_path
+		// to this hook (e.g. .../<session>.jsonl), NOT the subagent's
+		// .../<session>/subagents/agent-*.jsonl file, so isSubagentTranscript()
+		// never matches here. Suppress by the event so suppressForSubagents works
+		// as a safety net regardless of notifyOnSubagentStop.
+		if h.cfg.ShouldSuppressForSubagents() {
+			logging.Debug("SubagentStop: suppressing subagent notification (config: suppressForSubagents)")
 			return nil
 		}
-		// Then check the legacy notifyOnSubagentStop flag
+		// Not globally suppressed — honor the explicit opt-in flag.
 		if !h.cfg.Notifications.NotifyOnSubagentStop {
 			logging.Debug("SubagentStop: notifications disabled (config: notifyOnSubagentStop), skipping")
 			return nil
 		}
-		// If enabled, handle like Stop
+		// Opted in and not suppressed: handle like Stop.
 		logging.Debug("SubagentStop: notifications enabled (config), processing")
 		bench.Start("stop.analyze")
 		status, parsedMessages, err = h.handleStopEvent(&hookData)

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -742,10 +742,15 @@ func TestHandler_SubagentStop_DisabledByDefault(t *testing.T) {
 }
 
 func TestHandler_SubagentStop_EnabledInConfig(t *testing.T) {
+	// To actually receive subagent notifications a user must both opt in
+	// (notifyOnSubagentStop) AND disable the suppress-by-default safety net
+	// (suppressForSubagents), since the latter overrides the opt-in.
+	suppressForSubagents := false
 	cfg := &config.Config{
 		Notifications: config.NotificationsConfig{
 			Desktop:              config.DesktopConfig{Enabled: true},
-			NotifyOnSubagentStop: true, // Explicitly enabled
+			NotifyOnSubagentStop: true,                  // Explicitly enabled
+			SuppressForSubagents: &suppressForSubagents, // Safety net off
 		},
 		Statuses: map[string]config.StatusInfo{
 			"task_complete": {Title: "Task Complete"},
@@ -754,6 +759,8 @@ func TestHandler_SubagentStop_EnabledInConfig(t *testing.T) {
 
 	handler, mockNotif, _ := newTestHandler(t, cfg)
 
+	// Real-world payload: Claude Code passes the PARENT session transcript path
+	// to the SubagentStop hook, not a .../subagents/... path.
 	transcriptPath := createTempTranscript(t,
 		buildTranscriptWithTools([]string{"Write"}, 300))
 
@@ -769,9 +776,48 @@ func TestHandler_SubagentStop_EnabledInConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should send notification when explicitly enabled
+	// Should send notification when opted in and suppression is disabled
 	if !mockNotif.wasCalled() {
-		t.Error("expected notification for SubagentStop (explicitly enabled)")
+		t.Error("expected notification for SubagentStop (opted in, suppression disabled)")
+	}
+}
+
+// TestHandler_SubagentStop_SuppressForSubagentsOverridesOptIn verifies that the
+// suppress-by-default safety net wins even when notifyOnSubagentStop is enabled,
+// using the real-world payload (parent transcript path, NOT a /subagents/ path).
+// This is the behavior the path-based check could not deliver, because Claude
+// Code never passes the subagent's own transcript path to the SubagentStop hook.
+func TestHandler_SubagentStop_SuppressForSubagentsOverridesOptIn(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop:              config.DesktopConfig{Enabled: true},
+			NotifyOnSubagentStop: true, // Opted in...
+			// SuppressForSubagents: nil = default true (overrides the opt-in)
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+
+	transcriptPath := createTempTranscript(t,
+		buildTranscriptWithTools([]string{"Write"}, 300))
+
+	hookData := buildHookDataJSON(HookData{
+		SessionID:      "test-session-suppress-overrides",
+		TranscriptPath: transcriptPath, // parent path, no /subagents/ segment
+		CWD:            "/test",
+	})
+
+	err := handler.HandleHook("SubagentStop", hookData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT notify: suppressForSubagents (default true) overrides the opt-in.
+	if mockNotif.wasCalled() {
+		t.Error("expected NO notification: suppressForSubagents (default) overrides notifyOnSubagentStop")
 	}
 }
 
@@ -942,10 +988,11 @@ func TestHandler_SubagentStop_SuppressedForSubagentTranscript(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should NOT send notification even with notifyOnSubagentStop=true
-	// because suppressForSubagents takes priority for subagent paths
+	// Should NOT send notification even with notifyOnSubagentStop=true:
+	// suppressForSubagents (default true) suppresses every SubagentStop event,
+	// independent of the transcript path.
 	if mockNotif.wasCalled() {
-		t.Error("expected NO notification for subagent transcript in SubagentStop (suppressForSubagents default true)")
+		t.Error("expected NO notification for SubagentStop (suppressForSubagents default true)")
 	}
 }
 


### PR DESCRIPTION
Fixes #96.

## Problem

`suppressForSubagents` relies on `isSubagentTranscript()` matching `/subagents/` in the hook's `transcript_path`. But Claude Code passes the **parent session** transcript path to the `Stop` and `SubagentStop` hooks (verified in a real `notification-debug.log`: both hooks log the same `…/<session>.jsonl` path, never `…/subagents/agent-*.jsonl`). So the path check never matches, and `suppressForSubagents` does nothing — subagents are quiet today only because `notifyOnSubagentStop` defaults to `false`.

## Change

A `SubagentStop` event **always** denotes a subagent finishing, so the event type — not the transcript path — is the reliable signal. The `SubagentStop` branch now suppresses based on `suppressForSubagents` directly, making it an effective safety net regardless of `notifyOnSubagentStop`.

The `Stop` branch keeps the path-based check (a `Stop` is the main agent, so suppressing it should require a genuinely subagent/teammate transcript path); its comment now notes the check rarely matches on current Claude Code and is a forward-compatible guard.

### Behavior (`SubagentStop`)

| `notifyOnSubagentStop` | `suppressForSubagents` | Before | After |
|---|---|---|---|
| `false` (default) | `true` (default) | suppressed | suppressed |
| `false` | `false` | suppressed | suppressed |
| `true` | `true` (default) | **notifies** (path check inert) | **suppressed** |
| `true` | `false` | notifies | notifies |

**Default behavior is unchanged.** The only change is the opted-in + default-suppress combo: to get a notification per subagent you now set `notifyOnSubagentStop: true` **and** `suppressForSubagents: false`.

> Precedence note for review: I made `suppressForSubagents` (default `true`) win over `notifyOnSubagentStop`, since it reads as a global "keep subagents quiet" safety net. If you'd rather the explicit opt-in win (so `notifyOnSubagentStop: true` alone notifies), that's a one-line reorder — happy to flip it.

## Tests
- `TestHandler_SubagentStop_EnabledInConfig` now uses the real parent-path payload and sets `suppressForSubagents: false` to receive notifications.
- New `TestHandler_SubagentStop_SuppressForSubagentsOverridesOptIn`: opted-in + default suppress + parent path → no notification (the behavior the path check couldn't deliver).
- `TestHandler_SubagentStop_DisabledByDefault` and the `Stop` suppression tests are unchanged and still pass.
- `go test -race ./internal/hooks/... ./internal/config/...`, `go vet`, and `gofmt` are clean.

Docs: README options table gains a `suppressForSubagents` row and clarifies the `notifyOnSubagentStop` interaction; config field comments updated.

The `Notification` (`permission_prompt`) observation noted in #96 is intentionally **not** addressed here (its payload carries no subagent marker) and is left for discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `suppressForSubagents` configuration option (enabled by default) to control suppression of subagent stop notifications.

* **Documentation**
  * Updated configuration documentation to clarify the interaction between `suppressForSubagents` and `notifyOnSubagentStop` settings.
  * Documented default notification suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->