### PR TITLE
fix: resolve plugin paths without ambient env

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,17 +250,17 @@ func load(path, pluginRoot string) (*Config, error) {
 	}
 
 	// Expand environment variables in paths
-	config.Notifications.Desktop.AppIcon = filepath.Clean(expandEnv(config.Notifications.Desktop.AppIcon, pluginRoot))
+	config.Notifications.Desktop.AppIcon = expandPath(config.Notifications.Desktop.AppIcon, pluginRoot)
 	config.Notifications.Webhook.URL = platform.ExpandEnv(config.Notifications.Webhook.URL)
 
 	// Expand environment variables in sound paths
 	for status, info := range config.Statuses {
-		info.Sound = filepath.Clean(expandEnv(info.Sound, pluginRoot))
+		info.Sound = expandPath(info.Sound, pluginRoot)
 		config.Statuses[status] = info
 	}
 
 	// Apply defaults for missing fields
-	config.ApplyDefaults()
+	config.applyDefaults(pluginRoot)
 
 	return config, nil
 }
@@ -272,6 +272,14 @@ func expandEnv(value, pluginRoot string) string {
 		}
 		return os.Getenv(key)
 	})
+}
+
+func expandPath(value, pluginRoot string) string {
+	expanded := expandEnv(value, pluginRoot)
+	if expanded == "" {
+		return ""
+	}
+	return filepath.Clean(expanded)
 }
 
 // GetStableConfigDir returns the stable config directory outside the plugin cache.
@@ -390,6 +398,10 @@ func migrateConfig(oldPath, stablePath string) error {
 
 // ApplyDefaults fills in missing fields with default values
 func (c *Config) ApplyDefaults() {
+	c.applyDefaults("")
+}
+
+func (c *Config) applyDefaults(pluginRoot string) {
 	// Desktop defaults
 	if c.Notifications.Desktop.Volume == 0 {
 		c.Notifications.Desktop.Volume = 1.0 // Default to full volume
@@ -419,7 +431,7 @@ func (c *Config) ApplyDefaults() {
 	}
 
 	// Status defaults
-	defaults := DefaultConfig()
+	defaults := defaultConfig(pluginRoot)
 	if c.Statuses == nil {
 		c.Statuses = defaults.Statuses
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,8 +143,15 @@ const defaultSuppressQuestionAfterAnyNotificationSeconds = 7
 
 // DefaultConfig returns a config with sensible defaults
 func DefaultConfig() *Config {
+	return defaultConfig("")
+}
+
+func defaultConfig(resolvedPluginRoot string) *Config {
 	// Get plugin root from environment, fallback to current directory
-	pluginRoot := platform.ExpandEnv("${CLAUDE_PLUGIN_ROOT}")
+	pluginRoot := resolvedPluginRoot
+	if pluginRoot == "" {
+		pluginRoot = platform.ExpandEnv("${CLAUDE_PLUGIN_ROOT}")
+	}
 	if pluginRoot == "" || pluginRoot == "${CLAUDE_PLUGIN_ROOT}" {
 		pluginRoot = "."
 	}
@@ -223,9 +230,13 @@ func DefaultConfig() *Config {
 // Load loads configuration from a file
 // If the file doesn't exist, returns default config
 func Load(path string) (*Config, error) {
+	return load(path, "")
+}
+
+func load(path, pluginRoot string) (*Config, error) {
 	// If path doesn't exist, use default config
 	if !platform.FileExists(path) {
-		return DefaultConfig(), nil
+		return defaultConfig(pluginRoot), nil
 	}
 
 	data, err := os.ReadFile(path)
@@ -233,18 +244,18 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	config := DefaultConfig()
+	config := defaultConfig(pluginRoot)
 	if err := json.Unmarshal(data, config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
 	// Expand environment variables in paths
-	config.Notifications.Desktop.AppIcon = platform.ExpandEnv(config.Notifications.Desktop.AppIcon)
+	config.Notifications.Desktop.AppIcon = filepath.Clean(expandEnv(config.Notifications.Desktop.AppIcon, pluginRoot))
 	config.Notifications.Webhook.URL = platform.ExpandEnv(config.Notifications.Webhook.URL)
 
 	// Expand environment variables in sound paths
 	for status, info := range config.Statuses {
-		info.Sound = platform.ExpandEnv(info.Sound)
+		info.Sound = filepath.Clean(expandEnv(info.Sound, pluginRoot))
 		config.Statuses[status] = info
 	}
 
@@ -252,6 +263,15 @@ func Load(path string) (*Config, error) {
 	config.ApplyDefaults()
 
 	return config, nil
+}
+
+func expandEnv(value, pluginRoot string) string {
+	return os.Expand(value, func(key string) string {
+		if key == "CLAUDE_PLUGIN_ROOT" && pluginRoot != "" {
+			return pluginRoot
+		}
+		return os.Getenv(key)
+	})
 }
 
 // GetStableConfigDir returns the stable config directory outside the plugin cache.
@@ -290,7 +310,7 @@ func LoadFromPluginRoot(pluginRoot string) (*Config, error) {
 	}
 	if stableErr == nil {
 		if platform.FileExists(stablePath) {
-			cfg, err := Load(stablePath)
+			cfg, err := load(stablePath, pluginRoot)
 			if err != nil {
 				// Corrupted stable config — warn and fall through to old path
 				msg := fmt.Sprintf("warning: failed to load config from %s: %v, trying legacy path", stablePath, err)
@@ -305,13 +325,13 @@ func LoadFromPluginRoot(pluginRoot string) (*Config, error) {
 	// 2. Try old path (pluginRoot/config/config.json)
 	oldPath := filepath.Join(pluginRoot, "config", "config.json")
 	if platform.FileExists(oldPath) {
-		cfg, err := Load(oldPath)
+		cfg, err := load(oldPath, pluginRoot)
 		if err != nil {
 			// Corrupted old config — warn, return defaults (non-fatal)
 			msg := fmt.Sprintf("warning: corrupted config at %s, using defaults", oldPath)
 			fmt.Fprintln(os.Stderr, msg)
 			logging.Warn("%s", msg)
-			return DefaultConfig(), nil
+			return defaultConfig(pluginRoot), nil
 		}
 
 		// Migrate to stable path (best-effort)
@@ -327,7 +347,7 @@ func LoadFromPluginRoot(pluginRoot string) (*Config, error) {
 	}
 
 	// 3. Neither path has config — return defaults
-	return DefaultConfig(), nil
+	return defaultConfig(pluginRoot), nil
 }
 
 // migrateConfig copies config from oldPath to stablePath atomically.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -334,7 +334,9 @@ func TestLoadFromPluginRoot_WithEnvironmentVariables(t *testing.T) {
 
 func TestLoadFromPluginRoot_ExpandsUnsetPluginRootFromResolvedPath(t *testing.T) {
 	pluginRoot := t.TempDir()
+	setTestHome(t, t.TempDir())
 	t.Setenv("CLAUDE_PLUGIN_ROOT", "")
+	t.Setenv("TEST_SOUND_PATH", filepath.Join(pluginRoot, "custom.mp3"))
 
 	configDir := filepath.Join(pluginRoot, "config")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
@@ -343,7 +345,11 @@ func TestLoadFromPluginRoot_ExpandsUnsetPluginRootFromResolvedPath(t *testing.T)
 	configPath := filepath.Join(configDir, "config.json")
 	data := []byte(`{
 		"notifications": {"desktop": {"appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"}},
-		"statuses": {"task_complete": {"sound": "${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3"}}
+		"statuses": {
+			"task_complete": {"sound": "${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3"},
+			"question": {"sound": "$TEST_SOUND_PATH"},
+			"api_error": {"sound": ""}
+		}
 	}`)
 	if err := os.WriteFile(configPath, data, 0o600); err != nil {
 		t.Fatal(err)
@@ -361,6 +367,39 @@ func TestLoadFromPluginRoot_ExpandsUnsetPluginRootFromResolvedPath(t *testing.T)
 	wantSound := filepath.Join(pluginRoot, "sounds", "task-complete.mp3")
 	if got := cfg.Statuses["task_complete"].Sound; got != wantSound {
 		t.Errorf("sound = %q, want %q", got, wantSound)
+	}
+	if got := cfg.Statuses["question"].Sound; got != filepath.Join(pluginRoot, "custom.mp3") {
+		t.Errorf("custom sound = %q", got)
+	}
+	if got := cfg.Statuses["api_error"].Sound; got != "" {
+		t.Errorf("empty sound = %q, want empty", got)
+	}
+}
+
+func TestLoadFromPluginRoot_NullStatusesUseResolvedRoot(t *testing.T) {
+	pluginRoot := t.TempDir()
+	setTestHome(t, t.TempDir())
+	configDir := filepath.Join(pluginRoot, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"statuses": null}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromPluginRoot(pluginRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(pluginRoot, "sounds", "task-complete.mp3")
+	if got := cfg.Statuses["task_complete"].Sound; got != want {
+		t.Errorf("default sound = %q, want %q", got, want)
+	}
+}
+
+func TestExpandPath_PreservesEmptyValue(t *testing.T) {
+	if got := expandPath("", t.TempDir()); got != "" {
+		t.Fatalf("expandPath(empty) = %q, want empty", got)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -332,6 +332,38 @@ func TestLoadFromPluginRoot_WithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "https://example.com/hook", cfg.Notifications.Webhook.URL)
 }
 
+func TestLoadFromPluginRoot_ExpandsUnsetPluginRootFromResolvedPath(t *testing.T) {
+	pluginRoot := t.TempDir()
+	t.Setenv("CLAUDE_PLUGIN_ROOT", "")
+
+	configDir := filepath.Join(pluginRoot, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "config.json")
+	data := []byte(`{
+		"notifications": {"desktop": {"appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"}},
+		"statuses": {"task_complete": {"sound": "${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3"}}
+	}`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromPluginRoot(pluginRoot)
+	if err != nil {
+		t.Fatalf("LoadFromPluginRoot() error = %v", err)
+	}
+
+	wantIcon := filepath.Join(pluginRoot, "claude_icon.png")
+	if cfg.Notifications.Desktop.AppIcon != wantIcon {
+		t.Errorf("app icon = %q, want %q", cfg.Notifications.Desktop.AppIcon, wantIcon)
+	}
+	wantSound := filepath.Join(pluginRoot, "sounds", "task-complete.mp3")
+	if got := cfg.Statuses["task_complete"].Sound; got != wantSound {
+		t.Errorf("sound = %q, want %q", got, wantSound)
+	}
+}
+
 // === Tests for ApplyDefaults ===
 
 func TestApplyDefaults(t *testing.T) {


### PR DESCRIPTION
## What changed

- thread the resolved plugin root through config loading
- expand `CLAUDE_PLUGIN_ROOT` from that resolved value when the hook environment omits it
- normalize expanded icon and sound paths for Windows
- add a regression test covering an unset ambient variable

## Why

On Windows, Claude Code can launch hook subprocesses without `CLAUDE_PLUGIN_ROOT`. `os.ExpandEnv` then removed the prefix and produced root-relative `/sounds/...` and `/claude_icon.png` paths even though the executable-derived plugin root was already available to `LoadFromPluginRoot`.

## Validation

- `go test ./internal/config` passes
- `go test ./...` reaches unrelated audio packages but cannot compile `malgo` in this Windows environment because a CGO toolchain is unavailable

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration paths now correctly resolve relative to the detected plugin location, even when the plugin-root environment variable is unset.
  * Default status sounds consistently use the resolved plugin location.
  * Empty sound settings remain empty instead of being overwritten.
  * Configurations with no status definitions now safely receive the appropriate defaults.

* **Tests**
  * Added coverage for plugin-root path expansion, missing status definitions, and empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->