### PR TITLE
fix(templates): remove reserved 'None' option from bug report dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,6 @@ body:
       label: Terminal multiplexer (if any)
       description: Are you running inside tmux, zellij, or similar?
       options:
-        - None
         - tmux
         - tmux (iTerm2 -CC mode)
         - zellij


### PR DESCRIPTION
GitHub reserves the literal option 'None' and injects it automatically into non-required dropdowns, so the explicit entry made the template invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report form’s terminal multiplexer dropdown by removing the “None” option.
  * Existing multiplexer choices, “Other” fallback, and required-field validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->