### PR TITLE
fix(macos): avoid ambiguous Ghostty cwd tab focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Ghostty: cwd fallback no longer switches to an arbitrary same-directory tab** - click-to-focus selects a terminal by working directory only when exactly one tab matches, leaving ambiguous sessions to the existing window-level fallback instead ([#115](https://github.com/777genius/claude-notifications-go/issues/115)).
+
 ## [1.40.1] - 2026-07-17
 
 ### Changed

--- a/internal/notifier/ax_focus_darwin.go
+++ b/internal/notifier/ax_focus_darwin.go
@@ -615,15 +615,24 @@ on focusMatchingTerminal(searchPaths)
 		set allTerminals to terminals
 		repeat with candidate in searchPaths
 			set normalizedCandidate to my normalizePath(contents of candidate)
+			set matchCount to 0
+			set matchedTerminal to missing value
 			repeat with t in allTerminals
 				try
 					set termDir to my normalizePath(working directory of t)
 					if termDir is normalizedCandidate then
-						focus t
-						return true
+						set matchCount to matchCount + 1
+						set matchedTerminal to t
 					end if
 				end try
 			end repeat
+			if matchCount is 1 then
+				focus matchedTerminal
+				return true
+			end if
+			if matchCount is greater than 1 then
+				return false
+			end if
 		end repeat
 	end tell
 	return false

--- a/internal/notifier/ax_focus_darwin_test.go
+++ b/internal/notifier/ax_focus_darwin_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -308,5 +309,22 @@ func TestTryGhosttyExactFocus_FallsBackToCWDWhenTerminalIDFails(t *testing.T) {
 	wantCandidates := []string{"/tmp/project"}
 	if !reflect.DeepEqual(gotCandidates, wantCandidates) {
 		t.Fatalf("runner candidates = %#v, want %#v", gotCandidates, wantCandidates)
+	}
+}
+
+func TestGhosttyFocusAppleScript_RequiresUniqueCWDMatch(t *testing.T) {
+	countMatch := strings.Index(ghosttyFocusAppleScript, "set matchCount to matchCount + 1")
+	uniqueGuard := strings.Index(ghosttyFocusAppleScript, "if matchCount is 1 then")
+	focusMatch := strings.Index(ghosttyFocusAppleScript, "focus matchedTerminal")
+	ambiguousGuard := strings.Index(ghosttyFocusAppleScript, "if matchCount is greater than 1 then")
+
+	if countMatch < 0 || uniqueGuard < 0 || focusMatch < 0 || ambiguousGuard < 0 {
+		t.Fatalf("Ghostty cwd focus script must count matches and reject ambiguity:\n%s", ghosttyFocusAppleScript)
+	}
+	if !(countMatch < uniqueGuard && uniqueGuard < focusMatch && focusMatch < ambiguousGuard) {
+		t.Fatalf("Ghostty cwd focus script must count all matches before focusing:\n%s", ghosttyFocusAppleScript)
+	}
+	if strings.Contains(ghosttyFocusAppleScript, "focus t") {
+		t.Fatalf("Ghostty cwd focus script must not focus the first matching terminal:\n%s", ghosttyFocusAppleScript)
 	}
 }


### PR DESCRIPTION
## Summary

Make Ghostty's cwd-based click-to-focus fallback select a terminal only when exactly one tab matches the requested working directory.

When multiple tabs share the same cwd, the AppleScript now returns failure and allows the existing AXDocument window-level fallback to raise the window without switching to an arbitrary tab.

Fixes #115.

This patch was prepared with OpenAI Codex assistance and reviewed against the fallback order and the exact algorithm proposed in the issue.

## Changes

- count all Ghostty terminals matching each normalized cwd candidate
- focus only a unique match
- reject ambiguous matches without changing tabs
- add a regression test for count-before-focus behavior
- document the fix under `Unreleased`

## Validation

- `go test ./internal/notifier -run "TestGhostty|TestTryGhostty" -count=1 -v` - 9 passed
- `go vet ./internal/notifier` - passed
- `gofmt` on changed Go files - clean
- `git diff --check` - passed

Standalone `osacompile` validation is unavailable because Ghostty's scripting dictionary is not installed on this host. The macOS notifier tests validate the embedded script contract, and CI will exercise the repository's full platform matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ghostty click-to-focus behavior when multiple tabs share the same working directory.
  * A terminal is now selected by working directory only when exactly one matching tab exists; ambiguous matches use the existing fallback behavior.

* **Documentation**
  * Updated the unreleased changelog with this behavior correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->