### PR TITLE
fix(windows): stop click-to-focus console flash and wrong-window picks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,12 @@ jobs:
           LIST_SOUNDS_BINARY="${{ matrix.binary }}"
           LIST_SOUNDS_BINARY="${LIST_SOUNDS_BINARY//claude-notifications/list-sounds}"
           go build -ldflags="-s -w" -trimpath -o "dist/$LIST_SOUNDS_BINARY" ./cmd/list-sounds
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            echo "Building claude-notifications focus-handler (GUI subsystem, no console flash on toast click)..."
+            FOCUS_BINARY="${{ matrix.binary }}"
+            FOCUS_BINARY="${FOCUS_BINARY%.exe}-focus.exe"
+            go build -ldflags="-s -w -H=windowsgui" -trimpath -o "dist/$FOCUS_BINARY" ./cmd/claude-notifications
+          fi
 
       - name: Verify macOS deployment target
         if: matrix.platform == 'darwin'
@@ -302,6 +308,13 @@ jobs:
               exit 1
             fi
           done
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            focus_binary="${MAIN_BINARY%.exe}-focus.exe"
+            if [ ! -s "dist/$focus_binary" ]; then
+              echo "Missing or empty artifact: $focus_binary"
+              exit 1
+            fi
+          fi
         shell: bash
 
       - name: Make binaries executable (Unix)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ build-all: ## Build optimized binaries for all platforms
 	@GOOS=linux GOARCH=amd64 go build $(RELEASE_FLAGS) -o dist/$(BINARY)-linux-amd64 ./cmd/claude-notifications
 	@GOOS=linux GOARCH=arm64 go build $(RELEASE_FLAGS) -o dist/$(BINARY)-linux-arm64 ./cmd/claude-notifications
 	@GOOS=windows GOARCH=amd64 go build $(RELEASE_FLAGS) -o dist/$(BINARY)-windows-amd64.exe ./cmd/claude-notifications
+	@echo "Building claude-notifications focus-handler (GUI subsystem, no console flash on toast click)..."
+	@GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -H=windowsgui" -trimpath -o dist/$(BINARY)-windows-amd64-focus.exe ./cmd/claude-notifications
 	@echo "Building sound-preview..."
 	@GOOS=darwin GOARCH=amd64 go build $(RELEASE_FLAGS) -o dist/$(SOUND_PREVIEW)-darwin-amd64 ./cmd/sound-preview
 	@GOOS=darwin GOARCH=arm64 go build $(RELEASE_FLAGS) -o dist/$(SOUND_PREVIEW)-darwin-arm64 ./cmd/sound-preview

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -137,17 +137,25 @@ detect_platform() {
         SOUND_PREVIEW_NAME="sound-preview-${PLATFORM}-${ARCH}.exe"
         LIST_DEVICES_NAME="list-devices-${PLATFORM}-${ARCH}.exe"
         LIST_SOUNDS_NAME="list-sounds-${PLATFORM}-${ARCH}.exe"
+        # GUI-subsystem sibling of BINARY_NAME, registered as the click-to-focus
+        # target so a toast click never flashes a console window (see winfocus.go).
+        FOCUS_HANDLER_NAME="claude-notifications-${PLATFORM}-${ARCH}-focus.exe"
     else
         BINARY_NAME="claude-notifications-${PLATFORM}-${ARCH}"
         SOUND_PREVIEW_NAME="sound-preview-${PLATFORM}-${ARCH}"
         LIST_DEVICES_NAME="list-devices-${PLATFORM}-${ARCH}"
         LIST_SOUNDS_NAME="list-sounds-${PLATFORM}-${ARCH}"
+        FOCUS_HANDLER_NAME=""
     fi
 
     BINARY_PATH="${SCRIPT_DIR}/${BINARY_NAME}"
     SOUND_PREVIEW_PATH="${SCRIPT_DIR}/${SOUND_PREVIEW_NAME}"
     LIST_DEVICES_PATH="${SCRIPT_DIR}/${LIST_DEVICES_NAME}"
     LIST_SOUNDS_PATH="${SCRIPT_DIR}/${LIST_SOUNDS_NAME}"
+    FOCUS_HANDLER_PATH=""
+    if [ -n "$FOCUS_HANDLER_NAME" ]; then
+        FOCUS_HANDLER_PATH="${SCRIPT_DIR}/${FOCUS_HANDLER_NAME}"
+    fi
     CHECKSUMS_PATH="${SCRIPT_DIR}/.checksums.txt"
 
     configure_curl_options
@@ -586,7 +594,7 @@ check_github_availability() {
 check_existing() {
     if [ "$FORCE_UPDATE" = true ]; then
         echo -e "${BLUE}🔄 Force update requested, removing old files...${NC}"
-        rm -f "$BINARY_PATH" "$SOUND_PREVIEW_PATH" "$LIST_DEVICES_PATH" "$LIST_SOUNDS_PATH" 2>/dev/null
+        rm -f "$BINARY_PATH" "$SOUND_PREVIEW_PATH" "$LIST_DEVICES_PATH" "$LIST_SOUNDS_PATH" "$FOCUS_HANDLER_PATH" 2>/dev/null
         # Remove symlinks (Unix) and .bat wrappers (Windows)
         rm -f "${SCRIPT_DIR}/claude-notifications" "${SCRIPT_DIR}/sound-preview" "${SCRIPT_DIR}/list-devices" "${SCRIPT_DIR}/list-sounds" 2>/dev/null
         rm -f "${SCRIPT_DIR}/claude-notifications.bat" "${SCRIPT_DIR}/sound-preview.bat" "${SCRIPT_DIR}/list-devices.bat" "${SCRIPT_DIR}/list-sounds.bat" 2>/dev/null
@@ -656,11 +664,16 @@ download_utilities() {
     download_utility "$SOUND_PREVIEW_NAME" "$SOUND_PREVIEW_PATH" || true
     download_utility "$LIST_DEVICES_NAME" "$LIST_DEVICES_PATH" || true
     download_utility "$LIST_SOUNDS_NAME" "$LIST_SOUNDS_PATH" || true
+    if [ -n "$FOCUS_HANDLER_NAME" ]; then
+        download_utility "$FOCUS_HANDLER_NAME" "$FOCUS_HANDLER_PATH" || true
+    fi
 
     # Create symlinks for utilities (may fail if downloads failed - that's OK)
     create_utility_symlink "sound-preview" "$SOUND_PREVIEW_NAME" "$SOUND_PREVIEW_PATH" || true
     create_utility_symlink "list-devices" "$LIST_DEVICES_NAME" "$LIST_DEVICES_PATH" || true
     create_utility_symlink "list-sounds" "$LIST_SOUNDS_NAME" "$LIST_SOUNDS_PATH" || true
+    # No symlink for the focus handler: it's only ever launched by the Go code's
+    # own registry entry via its full path, never invoked by name from a shell.
 }
 
 # Create symlink for a utility binary

--- a/cmd/claude-notifications/main.go
+++ b/cmd/claude-notifications/main.go
@@ -483,6 +483,12 @@ func runPlaySound(args []string) {
 // launches the registered claude-notify-focus: protocol with the encoded focus
 // context as the single argument; we decode it and raise the terminal window.
 func runFocusWindows(args []string) {
+	// Clicking a toast's protocol-activation link launches this process with no
+	// inherited console; Windows auto-creates and shows one for the duration of
+	// this console-subsystem binary. Detach immediately to cut the visible
+	// flash as short as possible.
+	winfocus.HideConsole()
+
 	if len(args) < 1 {
 		fmt.Fprintln(os.Stderr, "Error: focus-windows requires a focus URI argument")
 		os.Exit(1)

--- a/docs/CLICK_TO_FOCUS.md
+++ b/docs/CLICK_TO_FOCUS.md
@@ -122,13 +122,13 @@ Clicking a notification raises the terminal **window** that started the task. En
 
 How it works (no admin rights, no COM server):
 
-1. When the notification fires, the plugin walks up the process tree to the terminal window hosting Claude (Windows Terminal, VS Code, conhost, ConEmu, …) and records its window handle, PID, title and project folder.
-2. The toast is shown via [go-toast](https://git.sr.ht/~jackmordaunt/go-toast) with **protocol activation**, carrying that context in a `claude-notify-focus:` URI. A per-user handler for that scheme is registered under `HKCU\Software\Classes` (idempotent; refreshed if the binary moves).
-3. Clicking the toast launches the URI, which re-runs the binary's `focus-windows` subcommand. It re-finds the window (by handle, then PID, then title/folder) and raises it with `ShowWindow` + `SetForegroundWindow`.
+1. When the notification fires, the plugin walks up the process tree to the terminal window hosting Claude (Windows Terminal, VS Code, conhost, ConEmu, …) and records its window handle, PID, title and project folder. When one process owns several windows (e.g. Windows Terminal's shared "monarch"), it prefers the window whose title contains the project folder name to tell them apart.
+2. The toast is shown via [go-toast](https://git.sr.ht/~jackmordaunt/go-toast) with **protocol activation**, carrying that context in a `claude-notify-focus:` URI. A per-user handler for that scheme is registered under `HKCU\Software\Classes` (idempotent; refreshed if the binary moves), pointing at a second, GUI-subsystem build of the same binary (`claude-notifications-windows-amd64-focus.exe`) instead of the normal console-subsystem one — so the click never flashes a console window. If that sibling isn't present (older install), the handler falls back to the main binary.
+3. Clicking the toast launches the URI, which re-runs the focus-handler binary's `focus-windows` subcommand. It re-finds the window (by handle, then PID, then title/folder) and raises it with `ShowWindow` + `SetForegroundWindow`.
 
 ### Scope: window-level only
 
-Focus is **window-level**. Windows Terminal runs every tab and split pane inside one top-level window, and Win32 can only raise *windows*, not tabs — there is no public API to focus a specific WT tab by session (it's an open feature request on Windows Terminal). Additionally, when several WT windows run under a single `WindowsTerminal.exe` process, the plugin can resolve the terminal process but not which of its windows hosts a given tab. So:
+Focus is **window-level**. Windows Terminal runs every tab and split pane inside one top-level window, and Win32 can only raise *windows*, not tabs — there is no public API to focus a specific WT tab by session (it's an open feature request on Windows Terminal). So:
 
 - A single terminal window → raised reliably.
 - Multiple **separate** windows → best effort (the foreground / most-recent window is chosen); it may not be the exact one when the session is in a background window.

--- a/internal/winfocus/winfocus_other.go
+++ b/internal/winfocus/winfocus_other.go
@@ -17,3 +17,6 @@ func Focus(ctx FocusContext) error { return errWindowsOnly }
 
 // EnsureRegistered is a no-op on non-Windows platforms.
 func EnsureRegistered() error { return errWindowsOnly }
+
+// HideConsole is a no-op on non-Windows platforms.
+func HideConsole() {}

--- a/internal/winfocus/winfocus_windows.go
+++ b/internal/winfocus/winfocus_windows.go
@@ -33,6 +33,7 @@ var (
 
 	kernel32               = windows.NewLazySystemDLL("kernel32.dll")
 	procGetCurrentThreadId = kernel32.NewProc("GetCurrentThreadId")
+	procFreeConsole        = kernel32.NewProc("FreeConsole")
 )
 
 const (
@@ -101,24 +102,45 @@ func windowText(hwnd uintptr) string {
 	return windows.UTF16ToString(buf)
 }
 
-// windowForPID returns a window owned by pid, preferring one with a title.
-func windowForPID(list []winInfo, pid uint32) uintptr {
+// windowForPID returns a window owned by pid, resolving ambiguity when pid
+// owns several top-level windows (e.g. Windows Terminal's shared "monarch"
+// process hosting one window per project). Preference order:
+//  1. a window whose title contains folder — the only signal that can tell
+//     two same-PID windows for different projects apart.
+//  2. hint, if it is itself one of pid's windows (typically the foreground
+//     window at capture time).
+//  3. any window with a non-empty title.
+//  4. any window at all.
+func windowForPID(list []winInfo, pid uint32, folder string, hint uintptr) uintptr {
 	if pid == 0 {
 		return 0
 	}
-	var fallback uintptr
+	lower := strings.ToLower(strings.TrimSpace(folder))
+	var hintOwned, firstTitled, firstAny uintptr
 	for _, w := range list {
 		if w.pid != pid {
 			continue
 		}
-		if w.title != "" {
+		if lower != "" && w.title != "" && strings.Contains(strings.ToLower(w.title), lower) {
 			return w.hwnd
 		}
-		if fallback == 0 {
-			fallback = w.hwnd
+		if w.hwnd == hint && hintOwned == 0 {
+			hintOwned = w.hwnd
+		}
+		if w.title != "" && firstTitled == 0 {
+			firstTitled = w.hwnd
+		}
+		if firstAny == 0 {
+			firstAny = w.hwnd
 		}
 	}
-	return fallback
+	if hintOwned != 0 {
+		return hintOwned
+	}
+	if firstTitled != 0 {
+		return firstTitled
+	}
+	return firstAny
 }
 
 func windowByTitleContains(list []winInfo, needle string) uintptr {
@@ -160,28 +182,19 @@ func CaptureFocusContext(cwd string) (FocusContext, bool) {
 	parents := parentMap()
 
 	// A single process can own several top-level windows — notably the Windows
-	// Terminal "monarch" hosting multiple windows. When the foreground window
-	// belongs to the terminal process we resolve to, prefer it: it is almost
-	// always the window the user was looking at when Claude produced output.
+	// Terminal "monarch" hosting one window per project. The foreground window
+	// is passed in as a hint (it's often the window the user was looking at),
+	// but windowForPID prefers an explicit folder-title match first: trusting
+	// "foreground window's PID matches this ancestor" alone is wrong whenever
+	// that shared PID owns windows for other projects too.
 	fg, _, _ := procGetForegroundWindow.Call()
-	fgPID := uint32(0)
-	if fg != 0 {
-		fgPID = pidForWindow(fg)
-	}
 
 	pid := windows.GetCurrentProcessId()
 	seen := map[uint32]bool{}
 	for i := 0; i < 32 && pid != 0 && !seen[pid]; i++ {
 		seen[pid] = true
 
-		hwnd := uintptr(0)
-		if fg != 0 && fgPID == pid {
-			hwnd = fg
-		}
-		if hwnd == 0 {
-			hwnd = windowForPID(list, pid)
-		}
-		if hwnd != 0 {
+		if hwnd := windowForPID(list, pid, folder, fg); hwnd != 0 {
 			return FocusContext{
 				HWND:   int64(hwnd),
 				PID:    pid,
@@ -211,7 +224,7 @@ func resolveWindow(ctx FocusContext) uintptr {
 			return hwnd
 		}
 	}
-	if hwnd := windowForPID(list, ctx.PID); hwnd != 0 {
+	if hwnd := windowForPID(list, ctx.PID, ctx.Folder, 0); hwnd != 0 {
 		return hwnd
 	}
 	for _, needle := range []string{ctx.Folder, ctx.Title} {
@@ -220,6 +233,18 @@ func resolveWindow(ctx FocusContext) uintptr {
 		}
 	}
 	return 0
+}
+
+// HideConsole detaches the calling process from its console. A process
+// launched with no inherited console (e.g. by clicking a toast's
+// protocol-activation link) gets one auto-created and shown by Windows for
+// the console-subsystem binary; calling this immediately on entry tears it
+// down again before the flash is visible for long. Safe to call even when a
+// real console is inherited (e.g. manual invocation from a terminal for
+// debugging) — FreeConsole only detaches this process, it doesn't close the
+// console window while other processes (the shell) remain attached to it.
+func HideConsole() {
+	procFreeConsole.Call()
 }
 
 // Focus raises the terminal window described by ctx to the foreground.
@@ -269,8 +294,8 @@ func forceForeground(hwnd uintptr) {
 }
 
 // EnsureRegistered registers (or refreshes) the click-to-focus URI handler under
-// HKCU pointing at the currently running executable. Idempotent: a no-op when
-// the stored command already matches.
+// HKCU pointing at the focus-handler executable. Idempotent: a no-op when the
+// stored command already matches.
 func EnsureRegistered() error {
 	exe, err := os.Executable()
 	if err != nil {
@@ -279,7 +304,8 @@ func EnsureRegistered() error {
 	if abs, err := filepath.Abs(exe); err == nil {
 		exe = abs
 	}
-	want := commandValue(exe)
+	target := focusHandlerExecutable(exe)
+	want := commandValue(target)
 
 	cmdPath := `Software\Classes\` + ProtocolScheme + `\shell\open\command`
 	if k, err := registry.OpenKey(registry.CURRENT_USER, cmdPath, registry.QUERY_VALUE); err == nil {
@@ -289,7 +315,25 @@ func EnsureRegistered() error {
 			return nil
 		}
 	}
-	return RegisterProtocolHandler(exe)
+	return RegisterProtocolHandler(target)
+}
+
+// focusHandlerExecutable returns the GUI-subsystem sibling of the running
+// console exe (same name plus a "-focus" suffix before the extension) that
+// should be registered as the click-to-focus target instead of exe itself.
+// Windows auto-creates and shows a console window for the instant a
+// console-subsystem process starts with no inherited console — exactly what
+// happens on a toast click — and that first paint can't be suppressed from
+// inside the process once it's running. A GUI-subsystem binary never gets one
+// allocated in the first place. Falls back to exe when the sibling hasn't
+// been installed alongside it (older install, or a dev build without one).
+func focusHandlerExecutable(exe string) string {
+	ext := filepath.Ext(exe)
+	sibling := strings.TrimSuffix(exe, ext) + "-focus" + ext
+	if _, err := os.Stat(sibling); err == nil {
+		return sibling
+	}
+	return exe
 }
 
 func commandValue(exe string) string {

--- a/internal/winfocus/winfocus_windows_test.go
+++ b/internal/winfocus/winfocus_windows_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package winfocus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFocusHandlerExecutablePrefersSibling(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "claude-notifications-windows-amd64.exe")
+	sibling := filepath.Join(dir, "claude-notifications-windows-amd64-focus.exe")
+
+	if err := os.WriteFile(sibling, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("write sibling: %v", err)
+	}
+
+	if got := focusHandlerExecutable(exe); got != sibling {
+		t.Errorf("focusHandlerExecutable(%q) = %q, want %q", exe, got, sibling)
+	}
+}
+
+func TestFocusHandlerExecutableFallsBackWhenSiblingMissing(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "claude-notifications-windows-amd64.exe")
+
+	if got := focusHandlerExecutable(exe); got != exe {
+		t.Errorf("focusHandlerExecutable(%q) = %q, want %q (fallback to self)", exe, got, exe)
+	}
+}
+
+func TestWindowForPIDPrefersFolderMatchOverForegroundHint(t *testing.T) {
+	// Two windows share one PID (e.g. Windows Terminal's shared "monarch"
+	// process hosting one window per project). The foreground hint points at
+	// the wrong project's window; the folder-title match must win anyway.
+	const sharedPID = 42
+	list := []winInfo{
+		{hwnd: 1, pid: sharedPID, title: "project-b - Windows Terminal"},
+		{hwnd: 2, pid: sharedPID, title: "project-a - Windows Terminal"},
+	}
+
+	got := windowForPID(list, sharedPID, "project-a", 1 /* fg hint wrongly points at window 1 */)
+	if got != 2 {
+		t.Errorf("windowForPID = %d, want 2 (folder match should beat the foreground hint)", got)
+	}
+}
+
+func TestWindowForPIDFallsBackToHintWhenNoFolderMatch(t *testing.T) {
+	const pid = 7
+	list := []winInfo{
+		{hwnd: 10, pid: pid, title: "unrelated title"},
+		{hwnd: 11, pid: pid, title: "also unrelated"},
+	}
+
+	got := windowForPID(list, pid, "project-a", 11)
+	if got != 11 {
+		t.Errorf("windowForPID = %d, want 11 (hint) when no window title matches the folder", got)
+	}
+}
+
+func TestWindowForPIDFallsBackToFirstTitledWindow(t *testing.T) {
+	const pid = 9
+	list := []winInfo{
+		{hwnd: 20, pid: pid, title: ""},
+		{hwnd: 21, pid: pid, title: "some title"},
+	}
+
+	got := windowForPID(list, pid, "", 0)
+	if got != 21 {
+		t.Errorf("windowForPID = %d, want 21 (first titled window)", got)
+	}
+}


### PR DESCRIPTION
Fixes #118

## Root causes

Two independent bugs in the Windows click-to-focus path, both more visible with multiple project folders open at once:

1. **Console flash.** The exe launched by the toast's protocol-activation click has no inherited console, so Windows auto-creates and shows one for the duration of the process — the visible flash. This happens as part of process creation, before any of our code runs, so nothing the process does after starting can prevent that first paint.
2. **Wrong or no window raised.** `windowForPID` picked the first same-PID window in Z-order, and `CaptureFocusContext` separately trusted the foreground window whenever its owning PID matched an ancestor of the hook process. Neither can tell apart multiple windows owned by one shared process — e.g. Windows Terminal's "monarch" process, which owns every WT window regardless of project. If a different project's window happened to be foreground (or simply came first in Z-order) at the moment a session finished, its handle got captured as the click target instead.

## Fixes

- `windowForPID` now prefers a same-PID window whose title contains the project folder name before falling back to the foreground-window hint, then the first titled window — resolving the shared-PID ambiguity using the one signal that can actually distinguish between projects.
- `resolveWindow` applies the same folder preference when re-finding the window at click time, instead of only checking it as an unscoped last resort.
- Click-to-focus notifications now register a second, GUI-subsystem build of the same binary (`claude-notifications-windows-amd64-focus.exe`) as the protocol-activation target. A GUI-subsystem process never gets a console auto-allocated, so there's nothing to flash. Falls back to the regular console binary if the sibling isn't installed yet (e.g. mid-upgrade).

## Changes

| File                                         | Change                                                                |
| -------------------------------------------- | --------------------------------------------------------------------- |
| `internal/winfocus/winfocus_windows.go`      | Folder-aware `windowForPID`; `focusHandlerExecutable` + `HideConsole` |
| `internal/winfocus/winfocus_other.go`        | `HideConsole` no-op stub for non-Windows                              |
| `internal/winfocus/winfocus_windows_test.go` | New unit tests for both fixes                                         |
| `cmd/claude-notifications/main.go`           | Calls `winfocus.HideConsole()` in `runFocusWindows`                   |
| `Makefile`                                   | Builds the `-focus.exe` GUI-subsystem sibling in `build-all`          |
| `.github/workflows/release.yml`              | Builds, verifies, and ships the `-focus.exe` asset (Windows only)     |
| `bin/install.sh`                             | Downloads the `-focus.exe` sibling alongside the main binary          |
| `docs/CLICK_TO_FOCUS.md`                     | Updated Windows section to describe the new mechanism                 |

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `bin/install_test.sh` passes
- [x] Manually verified on Windows 11 with multiple Windows Terminal windows open across different project folders: correct window is now raised consistently, and clicking the notification no longer flashes a console window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows click-to-focus behavior when multiple terminal windows are open.
  * Added project-aware window selection for more accurate focus targeting.
  * Windows focus actions no longer briefly flash a console window.

* **Bug Fixes**
  * Added fallback behavior when the dedicated Windows focus helper is unavailable.
  * Improved focus-handler registration and installation during updates.

* **Documentation**
  * Clarified Windows click-to-focus behavior, window selection, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->