### PR TITLE
Fix detect Alacritty terminal the focus target

### DIFF
--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -257,6 +257,13 @@ func GetTerminalName() string {
 		return "konsole"
 	}
 
+	// Check Alacritty (deliberately never sets TERM_PROGRAM, but exports
+	// ALACRITTY_WINDOW_ID into every window it spawns). Checked last so that a
+	// more specific indicator wins when a supported terminal is nested inside it.
+	if os.Getenv("ALACRITTY_WINDOW_ID") != "" {
+		return "alacritty"
+	}
+
 	// Fallback to generic terminal
 	return "Terminal"
 }

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -25,6 +25,7 @@ func saveTerminalEnv(t *testing.T) func() {
 		"XDG_SESSION_DESKTOP",
 		"WEZTERM_PANE",
 		"WEZTERM_UNIX_SOCKET",
+		"ALACRITTY_WINDOW_ID",
 	}
 	type envState struct {
 		value string
@@ -507,6 +508,33 @@ func TestGetTerminalName_TermProgramTakesPriority(t *testing.T) {
 	result := GetTerminalName()
 	if result != "alacritty" {
 		t.Errorf("GetTerminalName() with TERM_PROGRAM+VSCODE = %q, want %q", result, "alacritty")
+	}
+}
+
+func TestGetTerminalName_Alacritty(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("ALACRITTY_WINDOW_ID", "103739285932688")
+
+	result := GetTerminalName()
+	if result != "alacritty" {
+		t.Errorf("GetTerminalName() with ALACRITTY_WINDOW_ID = %q, want %q", result, "alacritty")
+	}
+}
+
+// A supported terminal running inside Alacritty inherits ALACRITTY_WINDOW_ID, so
+// the more specific indicator has to win or its windows are never found.
+func TestGetTerminalName_AlacrittyYieldsToMoreSpecificTerminal(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("ALACRITTY_WINDOW_ID", "103739285932688")
+	os.Setenv("KONSOLE_VERSION", "220401")
+
+	result := GetTerminalName()
+	if result != "konsole" {
+		t.Errorf("GetTerminalName() with ALACRITTY_WINDOW_ID+KONSOLE_VERSION = %q, want %q", result, "konsole")
 	}
 }
 


### PR DESCRIPTION
## Summary

Clicking a notification did nothing at all under Alacritty on Linux.

`GetTerminalName` identifies the terminal from `TERM_PROGRAM` plus a handful of
app-specific variables. Alacritty sets none of them — it deliberately omits `TERM_PROGRAM`,
considering it non-standard — so an Alacritty session fell through to the generic
`"Terminal"` fallback.

Key off `ALACRITTY_WINDOW_ID`, which Alacritty exports into every window it spawns.

## Testing

- `make test-race`, `make lint`, `golangci-lint` (the CI-pinned v2.12.2) — all clean
- Live on Linux under Alacritty: the click now raises the right window; before the change
  it did nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for Alacritty terminals.
* **Bug Fixes**
  * Improved terminal identification to preserve more specific detection when multiple terminal indicators are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->