### PR TITLE
fix(summary): read question and plan text from the hook payload

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -54,6 +54,10 @@ type HookData struct {
 	CWD            string `json:"cwd"`
 	ToolName       string `json:"tool_name,omitempty"`
 	HookEventName  string `json:"hook_event_name,omitempty"`
+	// ToolInput carries the raw arguments of the tool that is about to run
+	// (PreToolUse). It is the only authoritative source for the current call:
+	// the assistant message holding it has not reached the transcript yet.
+	ToolInput json.RawMessage `json:"tool_input,omitempty"`
 	// Team-related fields (present in TeammateIdle, TaskCreated, TaskCompleted hooks)
 	TeamName     string `json:"team_name,omitempty"`
 	TeammateName string `json:"teammate_name,omitempty"`
@@ -569,6 +573,13 @@ func (h *Handler) generateMessage(hookData *HookData, status analyzer.Status, me
 		if parsed, err := jsonl.ParseFile(hookData.TranscriptPath); err == nil {
 			body, actions = summary.GenerateFromMessagesStructured(parsed, status, h.cfg)
 		}
+	}
+
+	// PreToolUse announces a call that is not in the transcript yet, so the body
+	// derived above describes the previous turn. When the payload carries the tool
+	// arguments they are authoritative and win. Actions stay transcript-derived.
+	if fromInput := summary.BodyFromToolInput(hookData.ToolName, hookData.ToolInput); fromInput != "" {
+		body = fromInput
 	}
 
 	if body == "" {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -2394,3 +2394,121 @@ func setupTeamStateManager(t *testing.T, homeDir string) *teamstate.Manager {
 	t.Helper()
 	return teamstate.NewManager(filepath.Join(homeDir, ".claude"))
 }
+
+// TestHandler_PreToolUse_AskUserQuestion_PrefersToolInput is a regression test for
+// question notifications showing the PREVIOUS turn's text.
+//
+// PreToolUse fires before Claude Code appends the assistant message holding the
+// AskUserQuestion call to the transcript. Transcript-based extraction therefore
+// finds the previous turn's question-shaped text and shows that instead. The hook
+// payload carries the real question, so it must win.
+func TestHandler_PreToolUse_AskUserQuestion_PrefersToolInput(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+		},
+		Statuses: map[string]config.StatusInfo{
+			"question": {Title: "Question"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+
+	// Transcript ends on the previous turn — the call being announced is not in it.
+	transcriptPath := createTempTranscript(t, []jsonl.Message{
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "text", Text: "Let's set up the database"}},
+			},
+			Timestamp: "2025-01-01T12:00:00Z",
+		},
+		{
+			Type: "assistant",
+			Message: jsonl.MessageContent{
+				Role:    "assistant",
+				Content: []jsonl.Content{{Type: "text", Text: "Which database should we use?"}},
+			},
+			Timestamp: "2025-01-01T12:00:01Z",
+		},
+	})
+
+	hookData := buildHookDataJSON(HookData{
+		SessionID:      "test-question-prefers-tool-input",
+		ToolName:       "AskUserQuestion",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+		ToolInput:      json.RawMessage(`{"questions":[{"question":"Deploy to staging first?","header":"Deploy"}]}`),
+	})
+
+	if err := handler.HandleHook("PreToolUse", hookData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	call := mockNotif.lastCall()
+	if !strings.Contains(call.message, "Deploy to staging first?") {
+		t.Errorf("notification should show the current question, got: %q", call.message)
+	}
+	if strings.Contains(call.message, "Which database") {
+		t.Errorf("notification leaked the previous turn's question: %q", call.message)
+	}
+}
+
+// TestHandler_PreToolUse_AskUserQuestion_FallsBackWithoutToolInput pins the
+// pre-existing transcript-based behaviour for payloads that carry no tool_input,
+// so older Claude Code versions keep working.
+func TestHandler_PreToolUse_AskUserQuestion_FallsBackWithoutToolInput(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+		},
+		Statuses: map[string]config.StatusInfo{
+			"question": {Title: "Question"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+
+	transcriptPath := createTempTranscript(t, []jsonl.Message{
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "text", Text: "Let's set up the database"}},
+			},
+			Timestamp: "2025-01-01T12:00:00Z",
+		},
+		{
+			Type: "assistant",
+			Message: jsonl.MessageContent{
+				Role:    "assistant",
+				Content: []jsonl.Content{{Type: "text", Text: "Which database should we use?"}},
+			},
+			Timestamp: "2025-01-01T12:00:01Z",
+		},
+	})
+
+	hookData := buildHookDataJSON(HookData{
+		SessionID:      "test-question-no-tool-input",
+		ToolName:       "AskUserQuestion",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	})
+
+	if err := handler.HandleHook("PreToolUse", hookData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	if call := mockNotif.lastCall(); !strings.Contains(call.message, "Which database") {
+		t.Errorf("without tool_input the transcript-based body should be used, got: %q", call.message)
+	}
+}

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -1,6 +1,7 @@
 package summary
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -160,17 +161,78 @@ func generateQuestionBody(messages []jsonl.Message) string {
 // generatePlanBody generates the body text for plan_ready status (no actions appended).
 // Matches bash: lib/summarizer.sh lines 471-492.
 func generatePlanBody(messages []jsonl.Message) string {
-	plan := extractExitPlanModePlan(messages)
-	if plan != "" {
-		// Get first non-empty line, clean markdown
-		for _, line := range strings.Split(plan, "\n") {
-			cleaned := CleanMarkdown(line)
-			if strings.TrimSpace(cleaned) != "" {
-				return truncateText(cleaned, 150)
-			}
-		}
+	if headline := firstMeaningfulLine(extractExitPlanModePlan(messages)); headline != "" {
+		return headline
 	}
 	return "Plan is ready for review"
+}
+
+// BodyFromToolInput renders a notification body from the raw tool arguments a
+// PreToolUse hook carries, or "" when the tool has nothing worth showing.
+//
+// PreToolUse fires before Claude Code appends the assistant message holding the
+// tool call to the transcript, so transcript-based extraction describes the
+// PREVIOUS turn instead of the call being announced. The hook payload is the only
+// authoritative source at that point. Returning "" keeps callers on their
+// existing transcript-based path.
+func BodyFromToolInput(toolName string, raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	switch toolName {
+	case "AskUserQuestion":
+		return questionBodyFromToolInput(raw)
+	case "ExitPlanMode":
+		return planBodyFromToolInput(raw)
+	}
+	return ""
+}
+
+// questionBodyFromToolInput reads the first non-empty question out of an
+// AskUserQuestion payload: {"questions":[{"question":"...","header":"..."}]}.
+// AskUserQuestion accepts several questions at once; a notification only has room
+// for one, so the first is shown and the rest are left to the UI.
+func questionBodyFromToolInput(raw json.RawMessage) string {
+	var input struct {
+		Questions []struct {
+			Question string `json:"question"`
+		} `json:"questions"`
+	}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return ""
+	}
+
+	for _, q := range input.Questions {
+		if cleaned := CleanMarkdown(q.Question); strings.TrimSpace(cleaned) != "" {
+			return truncateText(cleaned, 150)
+		}
+	}
+	return ""
+}
+
+// planBodyFromToolInput reads the plan headline out of an ExitPlanMode payload:
+// {"plan":"markdown"}.
+func planBodyFromToolInput(raw json.RawMessage) string {
+	var input struct {
+		Plan string `json:"plan"`
+	}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return ""
+	}
+	return firstMeaningfulLine(input.Plan)
+}
+
+// firstMeaningfulLine returns the first non-blank line of text, markdown-stripped
+// and truncated for notification display, or "" when there is no such line.
+func firstMeaningfulLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		cleaned := CleanMarkdown(line)
+		if strings.TrimSpace(cleaned) != "" {
+			return truncateText(cleaned, 150)
+		}
+	}
+	return ""
 }
 
 // generateReviewBody generates the body text for review_complete status (no actions appended).

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -223,10 +223,27 @@ func planBodyFromToolInput(raw json.RawMessage) string {
 	return firstMeaningfulLine(input.Plan)
 }
 
-// firstMeaningfulLine returns the first non-blank line of text, markdown-stripped
-// and truncated for notification display, or "" when there is no such line.
+// firstMeaningfulLine returns the first non-blank prose line of text,
+// markdown-stripped and truncated for notification display, or "" when there is
+// no such line.
+//
+// Fenced code blocks are skipped by tracking the fence state as lines are
+// consumed. Cleaning each line in isolation is not enough: CleanMarkdown removes
+// a ```…``` pair, but a lone opening fence survives it and would surface the
+// language tag ("go") as the headline. Tracking state also covers an unterminated
+// fence, where no pair exists to match.
 func firstMeaningfulLine(text string) string {
+	inFence := false
+
 	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
 		cleaned := CleanMarkdown(line)
 		if strings.TrimSpace(cleaned) != "" {
 			return truncateText(cleaned, 150)

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -1822,3 +1822,105 @@ func TestGenerateFromMessagesStructured_EmptyMessages(t *testing.T) {
 		t.Errorf("actions = %q, want empty for empty messages", actions)
 	}
 }
+
+// === Tests for BodyFromToolInput ===
+
+// Payload shapes below mirror what Claude Code actually sends in the PreToolUse
+// hook: AskUserQuestion carries {"questions":[{"question":...}]} and ExitPlanMode
+// carries {"plan":"markdown"}.
+func TestBodyFromToolInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		raw      string
+		expected string
+	}{
+		{
+			name:     "AskUserQuestion returns the question",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":[{"question":"Deploy to staging first?","header":"Deploy","multiSelect":false,"options":[{"label":"Yes","description":"ship it"}]}]}`,
+			expected: "Deploy to staging first?",
+		},
+		{
+			name:     "AskUserQuestion strips markdown from the question",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":[{"question":"Use **Postgres** or ` + "`sqlite`" + `?"}]}`,
+			expected: "Use Postgres or sqlite?",
+		},
+		{
+			name:     "AskUserQuestion with several questions shows the first",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":[{"question":"Which database?"},{"question":"Which region?"}]}`,
+			expected: "Which database?",
+		},
+		{
+			name:     "AskUserQuestion skips a blank leading question",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":[{"question":"   "},{"question":"Which region?"}]}`,
+			expected: "Which region?",
+		},
+		{
+			name:     "AskUserQuestion with no questions falls back",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":[]}`,
+			expected: "",
+		},
+		{
+			name:     "ExitPlanMode returns the plan headline",
+			toolName: "ExitPlanMode",
+			raw:      `{"plan":"## Migrate the parser\n\n1. Extract the lexer\n2. Rewrite tests"}`,
+			expected: "Migrate the parser",
+		},
+		{
+			name:     "ExitPlanMode skips leading blank lines",
+			toolName: "ExitPlanMode",
+			raw:      `{"plan":"\n\n   \nAdd retry to the uploader"}`,
+			expected: "Add retry to the uploader",
+		},
+		{
+			name:     "ExitPlanMode with empty plan falls back",
+			toolName: "ExitPlanMode",
+			raw:      `{"plan":""}`,
+			expected: "",
+		},
+		{
+			name:     "unsummarized tool falls back",
+			toolName: "Bash",
+			raw:      `{"command":"rm -rf /"}`,
+			expected: "",
+		},
+		{
+			name:     "empty payload falls back",
+			toolName: "AskUserQuestion",
+			raw:      ``,
+			expected: "",
+		},
+		{
+			name:     "malformed JSON falls back",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":[`,
+			expected: "",
+		},
+		{
+			name:     "unexpected shape falls back",
+			toolName: "AskUserQuestion",
+			raw:      `{"questions":"not an array"}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BodyFromToolInput(tt.toolName, json.RawMessage(tt.raw))
+			if got != tt.expected {
+				t.Errorf("BodyFromToolInput(%q, %q) = %q, want %q", tt.toolName, tt.raw, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBodyFromToolInput_NilPayload(t *testing.T) {
+	if got := BodyFromToolInput("AskUserQuestion", nil); got != "" {
+		t.Errorf("nil payload should fall back, got %q", got)
+	}
+}

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -1884,6 +1884,24 @@ func TestBodyFromToolInput(t *testing.T) {
 			expected: "",
 		},
 		{
+			name:     "ExitPlanMode skips a leading fenced code block",
+			toolName: "ExitPlanMode",
+			raw:      `{"plan":"` + "```" + `go\nfunc main() {}\n` + "```" + `\n\nExtract the lexer first"}`,
+			expected: "Extract the lexer first",
+		},
+		{
+			name:     "ExitPlanMode with an unterminated fence falls back",
+			toolName: "ExitPlanMode",
+			raw:      `{"plan":"` + "```" + `\nfunc main() {}\n\nExtract the lexer first"}`,
+			expected: "",
+		},
+		{
+			name:     "ExitPlanMode malformed JSON falls back",
+			toolName: "ExitPlanMode",
+			raw:      `{"plan":{"not":"a string"}}`,
+			expected: "",
+		},
+		{
 			name:     "unsummarized tool falls back",
 			toolName: "Bash",
 			raw:      `{"command":"rm -rf /"}`,


### PR DESCRIPTION
## Problem

Question notifications show text from an **earlier turn** instead of the question being asked.

`PreToolUse` fires *before* Claude Code appends the assistant message holding the tool call to the transcript, so every transcript-based lookup in `generateMessage` describes an earlier turn. Four symptoms, one root cause:

| Situation | Body shown today |
|---|---|
| `question`, previous `AskUserQuestion` within 60s | the **previous question** — `extractAskUserQuestion` finds the stale `tool_use` and its `isRecent` guard still accepts it |
| `question`, otherwise | arbitrary prose from the previous turn — falls through to the "find question-shaped text in recent assistant messages" strategy |
| `question`, first turn of a session | `Claude needs your input to continue` |
| `plan_ready` | the **first plan of the session** — `extractExitPlanModePlan` goes through `FindLastToolUse`, which scans the whole transcript with no turn filter and no recency guard. With no earlier plan, `Plan is ready for review` |

The hook payload already carries the arguments of the call being announced, but `HookData` had no `tool_input` field, so nothing could use them.

Observed on Linux with v1.40.1. The notification body for a fresh `AskUserQuestion` was the *entire opening paragraph of an unrelated story* from the previous assistant turn.

## Fix

Parse `tool_input` as `json.RawMessage` and let it override the transcript-derived body when present.

The payload shape is **not guessed**. This repo already parses exactly these fields, just from the wrong source:

- `extractAskUserQuestion` reads `input.questions[0].question` (`internal/summary/summary.go`)
- `extractExitPlanModePlan` reads `input.plan` (same file)

This change only takes them from the authoritative source. Cross-checked against real `tool_use` records dumped from a live transcript.

## Prior art

This symptom has been chased twice before, both times from the transcript side:

- `fa323cc` (2025-10-19) — *"Fix question notification showing outdated text from previous response"*: filter assistant messages by the last user timestamp in the question summary
- `11d2622` (2026-02-20) — extends the same timestamp filtering to task and review summaries

The filtering is correct and this PR keeps it. It just cannot reach this case, and the reason is worth spelling out: `getRecentAssistantMessages` falls back to the **unfiltered** `GetLastAssistantMessages` when the current-turn window comes back empty (`internal/summary/summary.go`, the "backward compatibility and edge cases" branch). At `PreToolUse` that window is empty exactly when it matters — the assistant message holding the call has not been appended yet — so the compatibility fallback is the route the previous turn's text takes to the notification. That is the unrelated story paragraph in the report above.

Reading `tool_input` sidesteps the question of which transcript messages to trust, because the text is in the payload either way.

## Compatibility

`BodyFromToolInput` returns `""` whenever `tool_input` is absent, `null`, or does not match the expected shape, and callers then follow their existing transcript-based path. Older Claude Code versions and unexpected payload changes degrade to today's behaviour rather than breaking.

Action summaries (`📝 1 new  ▶ 2 cmds  ⏱ 41s`) deliberately stay transcript-derived — `countToolsByType` already scopes them to the current turn via the last user timestamp, so they were already correct.

## Testing

15 new tests. The regression test genuinely fails without the fix — with the override disabled it reproduces the reported symptom:

```
--- FAIL: TestHandler_PreToolUse_AskUserQuestion_PrefersToolInput
    notification should show the current question, got: "[bold test test] Which database should we use? ⏱ 1s"
    notification leaked the previous turn's question: "[bold test test] Which database should we use? ⏱ 1s"
```

`TestHandler_PreToolUse_AskUserQuestion_FallsBackWithoutToolInput` pins the pre-existing behaviour for payloads with no `tool_input`.

- `go test ./...` — all packages pass
- `go test -race ./internal/hooks/ ./internal/summary/` — pass
- `golangci-lint run` (v2, repo config) — 0 issues
- Verified end-to-end through `hook-wrapper.sh` against a real transcript on Linux/KDE: body is the current question, action suffix preserved

## Notes for review

Two deliberate choices, happy to change either:

1. **The override is gated on `ToolName`, not on the hook event name.** In practice only `PreToolUse` carries `tool_name`/`tool_input` (`Notification` and `Stop` log an empty `tool=`), and if another event ever carried them, using the real arguments would still be more correct. Easy to tighten to `hook_event_name == "PreToolUse"` if you prefer an explicit guard.
2. **`AskUserQuestion` accepts up to 4 questions; only the first is shown.** A 150-char notification has no room for more, and the UI shows the rest.

## Out of scope (found while working on this, not included)

- `FindLastToolUse` scans the entire transcript with no turn filter and no recency guard. `extractExitPlanModePlan` is one victim; this PR routes around it rather than fixing it. Adding turn filtering there looks worthwhile but is a broader behavioural change.
- Cross-package test pollution: `internal/dedup` tests use the hardcoded session id `test-session`, whose lock file matches the `claude-notification-test-*.lock` glob that `newTestHandler` deletes on startup in `internal/hooks`. Running both packages in parallel occasionally fails `TestCheckEarlyDuplicate`. Seen once in ~6 full runs; pre-existing, and this PR adds 2 call sites to the existing 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop notifications for questions and plans by rendering content directly from tool-provided input when available.
  * Prevented notifications from showing outdated question text from earlier transcript turns.
  * Added graceful fallback to transcript-derived content when tool input is missing.
  * Enhanced notification formatting by extracting the first meaningful text, stripping markdown, and truncating long messages.

* **Tests**
  * Added regression tests to verify correct notification behavior for tool input present vs absent.
  * Extended unit tests for tool-input-to-notification rendering, including malformed/empty/unsupported payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
