### PR TITLE
fix(hooks): wait for the message that closes a turn before notifying

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -631,19 +631,34 @@ func turnStillWriting(messages []jsonl.Message) bool {
 	if len(window) == 0 {
 		return true
 	}
-	return !hasTextBlock(window[len(window)-1])
+	return !messageClosesTurn(window[len(window)-1])
 }
 
-// hasTextBlock reports whether an assistant message carries prose. Thinking blocks
-// are a distinct content type and deliberately do not count: they never reach the
-// notification body, so a turn that has only thought is still unfinished.
-func hasTextBlock(msg jsonl.Message) bool {
+// messageClosesTurn reports whether an assistant message is the answer that ends the
+// turn: it carries prose, and holds no tool call still waiting to run.
+//
+// Prose and a tool call can share one message. That shape is rare — one message in
+// 15366 across the transcripts on hand — but when it happens the call has yet to
+// run, so whatever was said alongside it is a preamble, not the answer.
+//
+// Thinking blocks are a distinct content type and deliberately do not count either:
+// they never reach the notification body, so a turn that has only thought is still
+// unfinished.
+func messageClosesTurn(msg jsonl.Message) bool {
+	prose := false
+
 	for _, content := range msg.Message.Content {
-		if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
-			return true
+		switch content.Type {
+		case "tool_use":
+			return false
+		case "text":
+			if strings.TrimSpace(content.Text) != "" {
+				prose = true
+			}
 		}
 	}
-	return false
+
+	return prose
 }
 
 // statusEndsTheTurn reports whether a status is settled by something other than a

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -556,12 +556,14 @@ func skipUTF8BOM(input io.Reader) io.Reader {
 	return reader
 }
 
-// analyzeSettledTranscript analyzes the transcript, re-reading it while the turn
-// that just ended is still missing from the file.
+// analyzeSettledTranscript analyzes the transcript, re-reading it while the message
+// that ends the turn is still missing from the file.
 //
-// Only an empty analysis window is worth waiting on. Every other verdict is
-// settled and returns immediately — including StatusUnknown produced by
-// notifyOnTextResponse being switched off, which no amount of waiting will change.
+// The wait covers the body as much as the status. A turn that used tools classifies
+// correctly from its tool_use records alone, but generateTaskBody reads the last
+// text in the window, and the text closing the turn is exactly what has not landed
+// yet — so the notification falls back to "Task completed successfully", or worse,
+// shows something said before the tool ran as though it were the conclusion.
 func (h *Handler) analyzeSettledTranscript(transcriptPath string) (analyzer.Status, []jsonl.Message, error) {
 	status, messages, err := analyzer.AnalyzeTranscriptWithMessages(transcriptPath, h.cfg)
 	if err != nil {
@@ -572,7 +574,7 @@ func (h *Handler) analyzeSettledTranscript(transcriptPath string) (analyzer.Stat
 	maxRetries := int(transcriptSettleWait / transcriptSettleInterval)
 	lastSize, sized := transcriptSize(transcriptPath)
 
-	for retry := 1; status == analyzer.StatusUnknown && turnMissingFromTranscript(messages); retry++ {
+	for retry := 1; !statusEndsTheTurn(status) && turnStillWriting(messages); retry++ {
 		// The ceiling is wall-clock rather than a sleep count. A transcript that grows
 		// on every poll without gaining an assistant record — system entries, tool
 		// results and snapshots all enlarge the file — defeats the stat gate below and
@@ -617,12 +619,49 @@ func transcriptSize(path string) (int64, bool) {
 	return info.Size(), true
 }
 
-// turnMissingFromTranscript reports whether the transcript holds no assistant
-// message after the last user message. That is the signature of a Stop hook that
-// outran Claude Code's write of the message finishing the turn.
-func turnMissingFromTranscript(messages []jsonl.Message) bool {
-	userTS := jsonl.GetLastUserTimestamp(messages)
-	return len(jsonl.FilterMessagesAfterTimestamp(messages, userTS)) == 0
+// turnStillWriting reports whether the transcript is missing the message that ends
+// the turn: either nothing follows the last user message, or what does still ends on
+// a tool call. Claude Code writes that closing message after it spawns the Stop
+// hook, so both shapes mean the same thing — the turn is not on disk yet.
+//
+// Measured over 1944 real turns, 3% end without ever producing a closing text and
+// so wait out the ceiling. The other 97% settle in about 80ms.
+func turnStillWriting(messages []jsonl.Message) bool {
+	window := jsonl.FilterMessagesAfterTimestamp(messages, jsonl.GetLastUserTimestamp(messages))
+	if len(window) == 0 {
+		return true
+	}
+	return !hasTextBlock(window[len(window)-1])
+}
+
+// hasTextBlock reports whether an assistant message carries prose. Thinking blocks
+// are a distinct content type and deliberately do not count: they never reach the
+// notification body, so a turn that has only thought is still unfinished.
+func hasTextBlock(msg jsonl.Message) bool {
+	for _, content := range msg.Message.Content {
+		if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// statusEndsTheTurn reports whether a status is settled by something other than a
+// closing message, so waiting for one would be time spent on nothing.
+//
+// A plan or a question ends the turn on the tool call itself — Claude is waiting on
+// the user, not still writing. Session limits and API errors come from the priority
+// checks ahead of the state machine and cannot change either.
+func statusEndsTheTurn(status analyzer.Status) bool {
+	switch status {
+	case analyzer.StatusPlanReady,
+		analyzer.StatusQuestion,
+		analyzer.StatusSessionLimitReached,
+		analyzer.StatusAPIError,
+		analyzer.StatusAPIErrorOverloaded:
+		return true
+	}
+	return false
 }
 
 // handleStopEvent handles Stop/SubagentStop hooks.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -32,10 +32,31 @@ import (
 // delay can never push the hook past the timeout configured in hooks.json.
 const maxNotifyDelaySeconds = 25
 
+// Claude Code appends the assistant message that ends a turn *after* it spawns the
+// Stop hook. Measured on Linux across 13 runs, the message lands 65-85ms after the
+// hook process starts, and response length does not change that — a three-word
+// reply and a 600-word reply are indistinguishable.
+//
+// A turn that used tools is unaffected: its tool_use records were written seconds
+// earlier, so the analyzer still sees a populated window. A text-only turn has
+// nothing else in the window, comes back StatusUnknown and is dropped without a
+// notification — every time, not intermittently.
+//
+// Re-read the transcript until the finishing message lands. The ceiling is ~24x the
+// slowest measured write and stays far inside the 30s hook timeout in hooks.json.
+// Waiting costs a stat per interval; the transcript is only re-parsed when it grows.
+const (
+	transcriptSettleWait     = 2 * time.Second
+	transcriptSettleInterval = 25 * time.Millisecond
+)
+
 // Test seams for the focus-aware / delayed desktop notification path.
 var (
 	isTerminalFocused = notifier.IsTerminalFocused
 	sleepFunc         = time.Sleep
+	// Kept separate from sleepFunc so tests that stub the notify delay do not also
+	// stub the transcript wait, and vice versa.
+	settleSleepFunc = time.Sleep
 )
 
 type notificationDelivery struct {
@@ -534,6 +555,68 @@ func skipUTF8BOM(input io.Reader) io.Reader {
 	return reader
 }
 
+// analyzeSettledTranscript analyzes the transcript, re-reading it while the turn
+// that just ended is still missing from the file.
+//
+// Only an empty analysis window is worth waiting on. Every other verdict is
+// settled and returns immediately — including StatusUnknown produced by
+// notifyOnTextResponse being switched off, which no amount of waiting will change.
+func (h *Handler) analyzeSettledTranscript(transcriptPath string) (analyzer.Status, []jsonl.Message, error) {
+	status, messages, err := analyzer.AnalyzeTranscriptWithMessages(transcriptPath, h.cfg)
+	if err != nil {
+		return analyzer.StatusUnknown, nil, err
+	}
+
+	maxRetries := int(transcriptSettleWait / transcriptSettleInterval)
+	lastSize, sized := transcriptSize(transcriptPath)
+
+	for retry := 1; status == analyzer.StatusUnknown && turnMissingFromTranscript(messages); retry++ {
+		if retry > maxRetries {
+			logging.Debug("Transcript still has no assistant response after %v, giving up", transcriptSettleWait)
+			break
+		}
+
+		settleSleepFunc(transcriptSettleInterval)
+
+		// Re-parsing costs ~70ms on a multi-megabyte transcript while a stat costs
+		// microseconds, so only pay for the parse once the file has actually grown.
+		// Without this the ceiling above would bound the sleeping alone, and a long
+		// session could burn seconds of CPU re-reading an unchanged file.
+		size, ok := transcriptSize(transcriptPath)
+		if ok && sized && size == lastSize {
+			continue
+		}
+		lastSize, sized = size, ok
+
+		status, messages, err = analyzer.AnalyzeTranscriptWithMessages(transcriptPath, h.cfg)
+		if err != nil {
+			return analyzer.StatusUnknown, nil, err
+		}
+		logging.Debug("Transcript grew, re-analyzed after %v", time.Duration(retry)*transcriptSettleInterval)
+	}
+
+	return status, messages, nil
+}
+
+// transcriptSize reports the transcript's current size. The bool is false when the
+// file cannot be stat'd, which makes the caller re-parse rather than assume the
+// file is unchanged.
+func transcriptSize(path string) (int64, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	return info.Size(), true
+}
+
+// turnMissingFromTranscript reports whether the transcript holds no assistant
+// message after the last user message. That is the signature of a Stop hook that
+// outran Claude Code's write of the message finishing the turn.
+func turnMissingFromTranscript(messages []jsonl.Message) bool {
+	userTS := jsonl.GetLastUserTimestamp(messages)
+	return len(jsonl.FilterMessagesAfterTimestamp(messages, userTS)) == 0
+}
+
 // handleStopEvent handles Stop/SubagentStop hooks.
 // Returns the parsed messages alongside the status so callers can reuse them
 // (e.g., for summary generation) without re-reading the transcript file.
@@ -548,7 +631,7 @@ func (h *Handler) handleStopEvent(hookData *HookData) (analyzer.Status, []jsonl.
 		return analyzer.StatusUnknown, nil, nil
 	}
 
-	status, messages, err := analyzer.AnalyzeTranscriptWithMessages(hookData.TranscriptPath, h.cfg)
+	status, messages, err := h.analyzeSettledTranscript(hookData.TranscriptPath)
 	if err != nil {
 		logging.Error("Failed to analyze transcript: %v", err)
 		return analyzer.StatusUnknown, nil, nil

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -57,6 +57,7 @@ var (
 	// Kept separate from sleepFunc so tests that stub the notify delay do not also
 	// stub the transcript wait, and vice versa.
 	settleSleepFunc = time.Sleep
+	nowFunc         = time.Now
 )
 
 type notificationDelivery struct {
@@ -567,11 +568,18 @@ func (h *Handler) analyzeSettledTranscript(transcriptPath string) (analyzer.Stat
 		return analyzer.StatusUnknown, nil, err
 	}
 
+	deadline := nowFunc().Add(transcriptSettleWait)
 	maxRetries := int(transcriptSettleWait / transcriptSettleInterval)
 	lastSize, sized := transcriptSize(transcriptPath)
 
 	for retry := 1; status == analyzer.StatusUnknown && turnMissingFromTranscript(messages); retry++ {
-		if retry > maxRetries {
+		// The ceiling is wall-clock rather than a sleep count. A transcript that grows
+		// on every poll without gaining an assistant record — system entries, tool
+		// results and snapshots all enlarge the file — defeats the stat gate below and
+		// pays a full reparse each time, ~70ms on a multi-megabyte transcript. Counting
+		// sleeps alone would let that overrun the budget several times over. The retry
+		// count stays as a secondary bound in case the clock misbehaves.
+		if retry > maxRetries || !nowFunc().Before(deadline) {
 			logging.Debug("Transcript still has no assistant response after %v, giving up", transcriptSettleWait)
 			break
 		}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -2437,6 +2437,46 @@ func assistantReply() jsonl.Message {
 	}
 }
 
+// stubSettleClock swaps the settle wait's sleep and clock for a virtual pair, so
+// tests exercise the real ceiling arithmetic without waiting on anything.
+//
+// Each sleep advances the clock by its own argument plus perRetryCost, which stands
+// in for the transcript reparse the loop pays when the file has grown. onSleep runs
+// after the clock moves and receives the 1-based sleep number.
+//
+// Returns a pointer to the sleep count, read after HandleHook returns.
+func stubSettleClock(t *testing.T, perRetryCost time.Duration, onSleep func(n int)) *int {
+	t.Helper()
+
+	restoreSleep, restoreNow := settleSleepFunc, nowFunc
+	t.Cleanup(func() { settleSleepFunc, nowFunc = restoreSleep, restoreNow })
+
+	now := time.Unix(0, 0)
+	sleeps := 0
+
+	nowFunc = func() time.Time { return now }
+	settleSleepFunc = func(d time.Duration) {
+		now = now.Add(d + perRetryCost)
+		sleeps++
+		if onSleep != nil {
+			onSleep(sleeps)
+		}
+	}
+
+	return &sleeps
+}
+
+func settleTestConfig() *config.Config {
+	return &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+}
+
 // TestHandleStopEvent_WaitsForTranscriptToSettle is a regression test for text-only
 // turns never producing a notification.
 //
@@ -2445,28 +2485,15 @@ func assistantReply() jsonl.Message {
 // analysis window is populated; a text-only turn leaves it empty, the analyzer
 // returns StatusUnknown and the hook exits silently.
 func TestHandleStopEvent_WaitsForTranscriptToSettle(t *testing.T) {
-	cfg := &config.Config{
-		Notifications: config.NotificationsConfig{
-			Desktop: config.DesktopConfig{Enabled: true},
-		},
-		Statuses: map[string]config.StatusInfo{
-			"task_complete": {Title: "Task Complete"},
-		},
-	}
-
-	handler, mockNotif, _ := newTestHandler(t, cfg)
+	handler, mockNotif, _ := newTestHandler(t, settleTestConfig())
 	transcriptPath := textOnlyTurnStart(t)
 
 	// Claude Code lands the reply while the hook is in its second wait.
-	restore := settleSleepFunc
-	defer func() { settleSleepFunc = restore }()
-	sleeps := 0
-	settleSleepFunc = func(time.Duration) {
-		sleeps++
-		if sleeps == 2 {
+	sleeps := stubSettleClock(t, 0, func(n int) {
+		if n == 2 {
 			appendToTranscript(t, transcriptPath, assistantReply())
 		}
-	}
+	})
 
 	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
 		SessionID:      "test-settle-waits",
@@ -2483,29 +2510,17 @@ func TestHandleStopEvent_WaitsForTranscriptToSettle(t *testing.T) {
 	if call := mockNotif.lastCall(); call.status != analyzer.StatusTaskComplete {
 		t.Errorf("got status %v, want StatusTaskComplete", call.status)
 	}
-	if sleeps != 2 {
-		t.Errorf("should stop waiting as soon as the turn lands, slept %d times", sleeps)
+	if *sleeps != 2 {
+		t.Errorf("should stop waiting as soon as the turn lands, slept %d times", *sleeps)
 	}
 }
 
 // TestHandleStopEvent_SettleWaitIsBounded pins the ceiling: a turn that never lands
 // must not spin forever, and must not notify.
 func TestHandleStopEvent_SettleWaitIsBounded(t *testing.T) {
-	cfg := &config.Config{
-		Notifications: config.NotificationsConfig{
-			Desktop: config.DesktopConfig{Enabled: true},
-		},
-		Statuses: map[string]config.StatusInfo{
-			"task_complete": {Title: "Task Complete"},
-		},
-	}
+	handler, mockNotif, _ := newTestHandler(t, settleTestConfig())
 
-	handler, mockNotif, _ := newTestHandler(t, cfg)
-
-	restore := settleSleepFunc
-	defer func() { settleSleepFunc = restore }()
-	sleeps := 0
-	settleSleepFunc = func(time.Duration) { sleeps++ }
+	sleeps := stubSettleClock(t, 0, nil)
 
 	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
 		SessionID:      "test-settle-bounded",
@@ -2519,9 +2534,57 @@ func TestHandleStopEvent_SettleWaitIsBounded(t *testing.T) {
 	if mockNotif.wasCalled() {
 		t.Error("should not notify when the turn never lands")
 	}
-	if want := int(transcriptSettleWait / transcriptSettleInterval); sleeps != want {
+	if want := int(transcriptSettleWait / transcriptSettleInterval); *sleeps != want {
 		t.Errorf("slept %d times, want %d (%v ceiling at %v intervals)",
-			sleeps, want, transcriptSettleWait, transcriptSettleInterval)
+			*sleeps, want, transcriptSettleWait, transcriptSettleInterval)
+	}
+}
+
+// TestHandleStopEvent_SettleWaitHonoursElapsedTime covers a transcript that grows on
+// every poll without ever gaining an assistant record — system entries, tool results
+// and snapshots all enlarge the file. That defeats the stat gate, so every poll pays
+// a full reparse. Counting sleeps alone would let those reparses run several times
+// past the ceiling, so the loop must stop on elapsed time instead.
+func TestHandleStopEvent_SettleWaitHonoursElapsedTime(t *testing.T) {
+	handler, mockNotif, _ := newTestHandler(t, settleTestConfig())
+	transcriptPath := textOnlyTurnStart(t)
+
+	// 70ms per retry is the measured reparse cost of a multi-megabyte transcript.
+	const reparseCost = 70 * time.Millisecond
+
+	sleeps := stubSettleClock(t, reparseCost, func(int) {
+		// Grow the file without adding an assistant record, so the window stays empty
+		// and the stat gate cannot skip the reparse.
+		appendToTranscript(t, transcriptPath, jsonl.Message{
+			Type:      "system",
+			Timestamp: "2025-01-01T12:00:01Z",
+		})
+	})
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-elapsed",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mockNotif.wasCalled() {
+		t.Error("should not notify when no assistant record ever lands")
+	}
+
+	maxRetries := int(transcriptSettleWait / transcriptSettleInterval)
+	if *sleeps >= maxRetries {
+		t.Errorf("elapsed time should stop the loop before the retry count does, slept %d of %d",
+			*sleeps, maxRetries)
+	}
+
+	// Each retry consumes interval + reparse, so the ceiling is reached in roughly
+	// transcriptSettleWait / (interval + reparse) rounds.
+	if want := int(transcriptSettleWait / (transcriptSettleInterval + reparseCost)); *sleeps > want+1 {
+		t.Errorf("slept %d times, expected about %d before hitting the %v ceiling",
+			*sleeps, want, transcriptSettleWait)
 	}
 }
 
@@ -2530,25 +2593,15 @@ func TestHandleStopEvent_SettleWaitIsBounded(t *testing.T) {
 // wait. Here notifyOnTextResponse is off, which no amount of waiting would change.
 func TestHandleStopEvent_SettledUnknownDoesNotWait(t *testing.T) {
 	notifyOnText := false
-	cfg := &config.Config{
-		Notifications: config.NotificationsConfig{
-			Desktop:              config.DesktopConfig{Enabled: true},
-			NotifyOnTextResponse: &notifyOnText,
-		},
-		Statuses: map[string]config.StatusInfo{
-			"task_complete": {Title: "Task Complete"},
-		},
-	}
+	cfg := settleTestConfig()
+	cfg.Notifications.NotifyOnTextResponse = &notifyOnText
 
 	handler, mockNotif, _ := newTestHandler(t, cfg)
 
 	transcriptPath := textOnlyTurnStart(t)
 	appendToTranscript(t, transcriptPath, assistantReply())
 
-	restore := settleSleepFunc
-	defer func() { settleSleepFunc = restore }()
-	sleeps := 0
-	settleSleepFunc = func(time.Duration) { sleeps++ }
+	sleeps := stubSettleClock(t, 0, nil)
 
 	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
 		SessionID:      "test-settle-settled-unknown",
@@ -2559,8 +2612,8 @@ func TestHandleStopEvent_SettledUnknownDoesNotWait(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if sleeps != 0 {
-		t.Errorf("a settled verdict must not wait, slept %d times", sleeps)
+	if *sleeps != 0 {
+		t.Errorf("a settled verdict must not wait, slept %d times", *sleeps)
 	}
 	if mockNotif.wasCalled() {
 		t.Error("notifyOnTextResponse is off, so no notification is expected")

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -2619,3 +2619,187 @@ func TestHandleStopEvent_SettledUnknownDoesNotWait(t *testing.T) {
 		t.Error("notifyOnTextResponse is off, so no notification is expected")
 	}
 }
+
+// toolTurnStart builds a transcript for a turn that has called a tool and is still
+// writing its answer. withPreamble adds the text an assistant often emits before
+// reaching for a tool.
+func toolTurnStart(t *testing.T, withPreamble bool) string {
+	t.Helper()
+
+	msgs := []jsonl.Message{
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "text", Text: "read go.mod"}},
+			},
+			Timestamp: "2025-01-01T12:00:00Z",
+		},
+	}
+
+	if withPreamble {
+		msgs = append(msgs, jsonl.Message{
+			Type: "assistant",
+			Message: jsonl.MessageContent{
+				Role:    "assistant",
+				Content: []jsonl.Content{{Type: "text", Text: "Let me take a look."}},
+			},
+			Timestamp: "2025-01-01T12:00:01Z",
+		})
+	}
+
+	msgs = append(msgs,
+		jsonl.Message{
+			Type: "assistant",
+			Message: jsonl.MessageContent{
+				Role:    "assistant",
+				Content: []jsonl.Content{{Type: "tool_use", Name: "Read"}},
+			},
+			Timestamp: "2025-01-01T12:00:02Z",
+		},
+		jsonl.Message{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "tool_result"}},
+			},
+			Timestamp: "2025-01-01T12:00:03Z",
+		},
+	)
+
+	return createTempTranscript(t, msgs)
+}
+
+func closingAnswer() jsonl.Message {
+	return jsonl.Message{
+		Type: "assistant",
+		Message: jsonl.MessageContent{
+			Role:    "assistant",
+			Content: []jsonl.Content{{Type: "text", Text: "go.mod declares module claude-notifications on Go 1.21.5."}},
+		},
+		Timestamp: "2025-01-01T12:00:05Z",
+	}
+}
+
+// TestHandleStopEvent_WaitsForClosingTextAfterTool is a regression test for tool
+// turns notifying with the generic fallback body.
+//
+// The turn classifies fine from its tool_use record, so the status never needs the
+// wait — but generateTaskBody finds no text in the window and falls back to
+// "Task completed successfully". Waiting only on an empty window misses this
+// entirely, because a tool_use record makes the window non-empty.
+func TestHandleStopEvent_WaitsForClosingTextAfterTool(t *testing.T) {
+	handler, mockNotif, _ := newTestHandler(t, settleTestConfig())
+	transcriptPath := toolTurnStart(t, false)
+
+	sleeps := stubSettleClock(t, 0, func(n int) {
+		if n == 2 {
+			appendToTranscript(t, transcriptPath, closingAnswer())
+		}
+	})
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-tool-body",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	call := mockNotif.lastCall()
+	if !strings.Contains(call.message, "go.mod declares module") {
+		t.Errorf("body should be the answer that closes the turn, got: %q", call.message)
+	}
+	if strings.Contains(call.message, "Task completed successfully") {
+		t.Errorf("body fell back to the generic message: %q", call.message)
+	}
+	if *sleeps != 2 {
+		t.Errorf("should stop waiting as soon as the answer lands, slept %d times", *sleeps)
+	}
+}
+
+// TestHandleStopEvent_WaitsPastPreToolText is the quieter half of the same defect.
+// With text emitted before the tool call the body is not obviously broken — it is a
+// whole, readable sentence — it is just the wrong one, taken from before the work
+// happened rather than after.
+func TestHandleStopEvent_WaitsPastPreToolText(t *testing.T) {
+	handler, mockNotif, _ := newTestHandler(t, settleTestConfig())
+	transcriptPath := toolTurnStart(t, true)
+
+	stubSettleClock(t, 0, func(n int) {
+		if n == 2 {
+			appendToTranscript(t, transcriptPath, closingAnswer())
+		}
+	})
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-preamble",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	call := mockNotif.lastCall()
+	if !strings.Contains(call.message, "go.mod declares module") {
+		t.Errorf("body should be the answer that closes the turn, got: %q", call.message)
+	}
+	if strings.Contains(call.message, "Let me take a look") {
+		t.Errorf("body leaked the text written before the tool ran: %q", call.message)
+	}
+}
+
+// TestHandleStopEvent_StatusEndingTheTurnDoesNotWait guards the ceiling against
+// turns that end on the tool call itself. A question or a plan leaves Claude waiting
+// on the user, so there is no closing message coming and waiting would burn the full
+// budget for nothing.
+func TestHandleStopEvent_StatusEndingTheTurnDoesNotWait(t *testing.T) {
+	cfg := settleTestConfig()
+	cfg.Statuses["question"] = config.StatusInfo{Title: "Question"}
+
+	handler, _, _ := newTestHandler(t, cfg)
+
+	transcriptPath := createTempTranscript(t, []jsonl.Message{
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "text", Text: "which database?"}},
+			},
+			Timestamp: "2025-01-01T12:00:00Z",
+		},
+		{
+			Type: "assistant",
+			Message: jsonl.MessageContent{
+				Role:    "assistant",
+				Content: []jsonl.Content{{Type: "tool_use", Name: "AskUserQuestion"}},
+			},
+			Timestamp: "2025-01-01T12:00:02Z",
+		},
+	})
+
+	sleeps := stubSettleClock(t, 0, nil)
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-question-no-wait",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if *sleeps != 0 {
+		t.Errorf("a turn ending on its tool call must not wait, slept %d times", *sleeps)
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -2394,3 +2394,175 @@ func setupTeamStateManager(t *testing.T, homeDir string) *teamstate.Manager {
 	t.Helper()
 	return teamstate.NewManager(filepath.Join(homeDir, ".claude"))
 }
+
+// appendToTranscript writes one more record to an existing transcript, standing in
+// for Claude Code finishing its write while the hook waits.
+func appendToTranscript(t *testing.T, path string, msg jsonl.Message) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("failed to open transcript for append: %v", err)
+	}
+	defer f.Close()
+
+	if err := json.NewEncoder(f).Encode(msg); err != nil {
+		t.Fatalf("failed to append to transcript: %v", err)
+	}
+}
+
+func textOnlyTurnStart(t *testing.T) string {
+	t.Helper()
+
+	return createTempTranscript(t, []jsonl.Message{
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "text", Text: "tell me a joke"}},
+			},
+			Timestamp: "2025-01-01T12:00:00Z",
+		},
+	})
+}
+
+func assistantReply() jsonl.Message {
+	return jsonl.Message{
+		Type: "assistant",
+		Message: jsonl.MessageContent{
+			Role:    "assistant",
+			Content: []jsonl.Content{{Type: "text", Text: strings.Repeat("a joke ", 40)}},
+		},
+		Timestamp: "2025-01-01T12:00:05Z",
+	}
+}
+
+// TestHandleStopEvent_WaitsForTranscriptToSettle is a regression test for text-only
+// turns never producing a notification.
+//
+// Claude Code appends the assistant message that ends a turn after it spawns the
+// Stop hook. A turn that used tools still has its tool_use records on disk, so the
+// analysis window is populated; a text-only turn leaves it empty, the analyzer
+// returns StatusUnknown and the hook exits silently.
+func TestHandleStopEvent_WaitsForTranscriptToSettle(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+	transcriptPath := textOnlyTurnStart(t)
+
+	// Claude Code lands the reply while the hook is in its second wait.
+	restore := settleSleepFunc
+	defer func() { settleSleepFunc = restore }()
+	sleeps := 0
+	settleSleepFunc = func(time.Duration) {
+		sleeps++
+		if sleeps == 2 {
+			appendToTranscript(t, transcriptPath, assistantReply())
+		}
+	}
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-waits",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("text-only turn should still notify once the transcript lands")
+	}
+	if call := mockNotif.lastCall(); call.status != analyzer.StatusTaskComplete {
+		t.Errorf("got status %v, want StatusTaskComplete", call.status)
+	}
+	if sleeps != 2 {
+		t.Errorf("should stop waiting as soon as the turn lands, slept %d times", sleeps)
+	}
+}
+
+// TestHandleStopEvent_SettleWaitIsBounded pins the ceiling: a turn that never lands
+// must not spin forever, and must not notify.
+func TestHandleStopEvent_SettleWaitIsBounded(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+
+	restore := settleSleepFunc
+	defer func() { settleSleepFunc = restore }()
+	sleeps := 0
+	settleSleepFunc = func(time.Duration) { sleeps++ }
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-bounded",
+		TranscriptPath: textOnlyTurnStart(t),
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mockNotif.wasCalled() {
+		t.Error("should not notify when the turn never lands")
+	}
+	if want := int(transcriptSettleWait / transcriptSettleInterval); sleeps != want {
+		t.Errorf("slept %d times, want %d (%v ceiling at %v intervals)",
+			sleeps, want, transcriptSettleWait, transcriptSettleInterval)
+	}
+}
+
+// TestHandleStopEvent_SettledUnknownDoesNotWait guards the fast path: an unknown
+// verdict reached with a populated window is final, so the hook must not pay the
+// wait. Here notifyOnTextResponse is off, which no amount of waiting would change.
+func TestHandleStopEvent_SettledUnknownDoesNotWait(t *testing.T) {
+	notifyOnText := false
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop:              config.DesktopConfig{Enabled: true},
+			NotifyOnTextResponse: &notifyOnText,
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+
+	transcriptPath := textOnlyTurnStart(t)
+	appendToTranscript(t, transcriptPath, assistantReply())
+
+	restore := settleSleepFunc
+	defer func() { settleSleepFunc = restore }()
+	sleeps := 0
+	settleSleepFunc = func(time.Duration) { sleeps++ }
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-settled-unknown",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if sleeps != 0 {
+		t.Errorf("a settled verdict must not wait, slept %d times", sleeps)
+	}
+	if mockNotif.wasCalled() {
+		t.Error("notifyOnTextResponse is off, so no notification is expected")
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -178,25 +178,17 @@ func createTempTranscript(t *testing.T, messages []jsonl.Message) string {
 	return transcriptPath
 }
 
+// buildTranscriptWithTools builds a turn that calls each tool in order and then
+// answers.
+//
+// Each tool call gets its own assistant message, and the answer gets one more.
+// That is the shape Claude Code writes: across the transcripts on hand, exactly one
+// assistant message in 15366 carried a tool call and prose together. Packing them
+// into a single message would make these fixtures describe a turn that has already
+// answered while a tool call is still pending, which is not a state the hook can
+// ever observe.
 func buildTranscriptWithTools(tools []string, textLength int) []jsonl.Message {
-	var content []jsonl.Content
-
-	// Add tools
-	for _, tool := range tools {
-		content = append(content, jsonl.Content{
-			Type: "tool_use",
-			Name: tool,
-		})
-	}
-
-	// Add text
-	text := strings.Repeat("a", textLength)
-	content = append(content, jsonl.Content{
-		Type: "text",
-		Text: text,
-	})
-
-	return []jsonl.Message{
+	messages := []jsonl.Message{
 		{
 			Type: "user",
 			Message: jsonl.MessageContent{
@@ -207,15 +199,27 @@ func buildTranscriptWithTools(tools []string, textLength int) []jsonl.Message {
 			},
 			Timestamp: "2025-01-01T12:00:00Z",
 		},
-		{
+	}
+
+	for _, tool := range tools {
+		messages = append(messages, jsonl.Message{
 			Type: "assistant",
 			Message: jsonl.MessageContent{
 				Role:    "assistant",
-				Content: content,
+				Content: []jsonl.Content{{Type: "tool_use", Name: tool}},
 			},
 			Timestamp: "2025-01-01T12:00:01Z",
-		},
+		})
 	}
+
+	return append(messages, jsonl.Message{
+		Type: "assistant",
+		Message: jsonl.MessageContent{
+			Role:    "assistant",
+			Content: []jsonl.Content{{Type: "text", Text: strings.Repeat("a", textLength)}},
+		},
+		Timestamp: "2025-01-01T12:00:02Z",
+	})
 }
 
 func newTestHandler(t *testing.T, cfg *config.Config) (*Handler, *mockNotifier, *mockWebhook) {
@@ -2801,5 +2805,73 @@ func TestHandleStopEvent_StatusEndingTheTurnDoesNotWait(t *testing.T) {
 
 	if *sleeps != 0 {
 		t.Errorf("a turn ending on its tool call must not wait, slept %d times", *sleeps)
+	}
+}
+
+// TestHandleStopEvent_WaitsWhenTextSharesMessageWithToolUse covers prose and a tool
+// call arriving in one assistant message. The shape is rare — one message in 15366
+// across the transcripts on hand — but the tool has yet to run when it appears, so
+// the text beside it is a preamble and the turn is still unfinished.
+func TestHandleStopEvent_WaitsWhenTextSharesMessageWithToolUse(t *testing.T) {
+	handler, mockNotif, _ := newTestHandler(t, settleTestConfig())
+
+	transcriptPath := createTempTranscript(t, []jsonl.Message{
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "text", Text: "read go.mod"}},
+			},
+			Timestamp: "2025-01-01T12:00:00Z",
+		},
+		{
+			Type: "assistant",
+			Message: jsonl.MessageContent{
+				Role: "assistant",
+				Content: []jsonl.Content{
+					{Type: "text", Text: "Let me take a look."},
+					{Type: "tool_use", Name: "Read"},
+				},
+			},
+			Timestamp: "2025-01-01T12:00:02Z",
+		},
+		{
+			Type: "user",
+			Message: jsonl.MessageContent{
+				Role:    "user",
+				Content: []jsonl.Content{{Type: "tool_result"}},
+			},
+			Timestamp: "2025-01-01T12:00:03Z",
+		},
+	})
+
+	sleeps := stubSettleClock(t, 0, func(n int) {
+		if n == 2 {
+			appendToTranscript(t, transcriptPath, closingAnswer())
+		}
+	})
+
+	err := handler.HandleHook("Stop", buildHookDataJSON(HookData{
+		SessionID:      "test-settle-mixed-message",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	call := mockNotif.lastCall()
+	if !strings.Contains(call.message, "go.mod declares module") {
+		t.Errorf("body should be the answer that closes the turn, got: %q", call.message)
+	}
+	if strings.Contains(call.message, "Let me take a look") {
+		t.Errorf("text sharing a message with the tool call was treated as the answer: %q", call.message)
+	}
+	if *sleeps == 0 {
+		t.Error("a message holding a pending tool call must not end the wait")
 	}
 }


### PR DESCRIPTION
Fixes #111.

## Problem

Claude Code appends the message that ends a turn **after** it spawns the Stop hook. The hook reads a transcript that does not yet contain the turn it was fired for.

Measured with a wall-clock probe watching both the plugin log and the transcript file — deliberately not the `timestamp` field inside the records, which is a logical time, not a write time:

| | closing message lands, relative to hook start |
|---|---|
| 13 runs | **+65 to +85 ms** |

Response length makes no difference: a three-word reply and a 600-word one are indistinguishable.

That one fact produces three separate user-visible defects.

### 1. Text-only turns never notify at all

The analyzer's window is *assistant messages after the last user message*. For a turn with no tools the closing message is the only thing that would be in it, so the window is empty, the analyzer returns `StatusUnknown` and `handleStopEvent` exits silently — every time, not intermittently. Reproduced on demand with `claude -p`: **6/6 text-only turns silent, 2/2 tool turns fine.**

This is what #111 reports: *"long working turns notify, quick answers don't."*

### 2. Tool turns notify with a generic body

A turn that called a tool classifies correctly from its `tool_use` records, which were written seconds earlier — so nothing looks wrong. But `generateTaskBody` reads the *last text* in that window, and the closing text is exactly what is missing. With no prose before the tool call, the window holds none at all and the body falls back to `Task completed successfully`.

### 3. Tool turns notify with the wrong body

The quieter half of the same defect. When prose *was* emitted before the tool call, the body is a whole, readable sentence — just the wrong one, taken from before the work happened rather than after:

```
prompt   read the first 3 lines of go.mod, and say "starting now" before you read
body     starting now                          ← what the notification showed
         The first 3 lines of go.mod are: …    ← what it should have shown
```

Nothing about that notification looks broken, which is why it survives casual use.

## Prior art

**Issue #11** (closed) reports defect 1 and was answered in v1.10.0 with the `notifyOnTextResponse` option, default on — *"notifications weren't being sent for text-only responses (when Claude responds without using any tools)."*

The option is real and it is on. On this path it is simply unreachable: `AnalyzeTranscriptWithMessages` returns `StatusUnknown` at the empty-window guard (`len(filteredMessages) == 0`), which sits many branches *ahead* of the `ShouldNotifyOnTextResponse()` call that would have promoted the turn to `task_complete`; `handleStopEvent` then skips on `StatusUnknown`. The switch can only fire for a text-only turn whose closing message is already on disk — the case that was never broken. That is how #111 came to be filed for a symptom #11 had been told was fixed.

**Issue #119** (open) is adjacent rather than duplicate, and the two interact. It asks for the opposite guard: return `StatusUnknown` when the transcript is *stale*, so a finished session stops re-notifying on a headless resume. Both are the same underlying question — whether the transcript state the hook sees is final. This PR waits for a window that is about to fill; #119 wants to reject one that will never fill again. The recency check proposed there would sit cleanly on top of this: a stale window already ends with closing text, so the settle loop exits without a single sleep and the check sees exactly the state it sees today.

## Fix

Re-read the transcript until the last record in the window carries a text block, bounded at 2s in 25ms steps — about 24× the slowest measured write, and far inside the 30s hook timeout in `hooks.json`.

Thinking blocks deliberately do not count. They are a distinct content type that never reaches the notification body, so a turn that has only thought is still unfinished. (Confirmed against real transcripts: a `Thought for 2s` before a tool call does not change the outcome.)

**The wait is skipped for statuses a tool settles on its own.** A plan or a question ends the turn on the call itself, with Claude waiting on the user rather than still writing; session limits and API errors come from the priority checks ahead of the state machine. Waiting on those would spend the whole budget for nothing.

**Waiting costs a stat per interval, not a parse.** Parsing is the expensive part — 5.8ms for a 442KB transcript, 67.8ms for a 3963KB one — so the transcript is only re-parsed once it has grown, and the ceiling is enforced by elapsed time rather than a sleep count.

## What this changes, measured over 1944 real turns

| | share | |
|---|---|---|
| tool turns that get a correct body for the first time | **48.9%** | 950 turns |
| turns that end without ever producing closing text and wait out the ceiling | **3.1%** | 60 turns |
| turns whose status changes from `task_complete` to `review_complete` | **2.5%** | 48 turns |

That last row is worth calling out explicitly: read-only turns whose long answer finally arrives now satisfy the 200-character test in rule 1d of the state machine. That is what `review_complete` was written for, but the closing text never used to be on disk in time for it to fire. Users will see 🔍 where they saw ✅ on those turns.

## Verification

End-to-end against a real Claude Code install on Linux:

- **7/7** text-only turns that were silent before now notify, settling after 75–100ms — consistent with the 65–85ms write lag plus one polling interval
- the `starting now` reproduction above now shows the closing answer instead

Seven tests, four of which fail without the fix:

| test | pins |
|---|---|
| `WaitsForTranscriptToSettle` | the turn lands mid-wait → notifies, and stops immediately (asserts exactly 2 sleeps) |
| `WaitsForClosingTextAfterTool` | tool turn with no prose → body is the answer, not `Task completed successfully` |
| `WaitsPastPreToolText` | tool turn with prose → body is the answer, not what was said before the tool |
| `SettleWaitIsBounded` | the turn never lands → no spin, no notification (asserts exactly 80 sleeps) |
| `SettleWaitHonoursElapsedTime` | transcript grows every poll → stops on elapsed time, ~21 rounds not 80 |
| `StatusEndingTheTurnDoesNotWait` | a question → **zero** sleeps |
| `SettledUnknownDoesNotWait` | `notifyOnTextResponse` off → **zero** sleeps |

They drive the wait through an injected clock where each sleep advances virtual time, so they are deterministic rather than timing-dependent.

- `go test ./...` — all packages pass
- `go test -race ./internal/hooks/` — pass
- `golangci-lint run` (v2, repo config) — 0 issues

## Notes for review

- **On the mechanism in #111.** The report traces the same defect to the same early return, but proposes that the hook reads a transcript whose last line is *truncated* JSON, which `Parse` then drops silently at [`jsonl.go#L118-L121`](https://github.com/777genius/claude-notifications-go/blob/main/pkg/jsonl/jsonl.go#L118-L121). That is mechanically sound, and I could not reproduce it: sampling as fast as I could around the hook — 309 snapshots across three turns, plus a slower probe over four more — the closing line always appeared whole. I am not claiming the report is wrong; my sampling interval is roughly 3ms and the largest single line I captured was 4316 bytes, comfortably inside the size where a write is atomic anyway. It does not change the fix either way: `Parse` drops a truncated line, so the window ends up in the same state as if the line had not been written.
- **Timeout budget.** `maxNotifyDelaySeconds` is 25 so the hook stays inside the 30s timeout. The settle wait can add up to 2s ahead of it, leaving a 3s margin instead of 5s. Typical cost is ~80ms, and a turn that never lands returns before the notify delay applies, so the two do not compound in practice.
- **Dedup is unaffected.** Phase 1 runs before analysis and phase 2 (`AcquireLock`, the `O_EXCL` acquisition that actually guards) runs after it, so the wait shifts phase 2 as a whole; concurrent duplicate hooks still leave exactly one winner.
- **Separate sleep seam.** `settleSleepFunc` rather than the existing `sleepFunc`, so tests stubbing the notify delay do not silently stub this wait too.
- The 2s / 25ms constants are unexported. Say the word if you would prefer them configurable, or a tighter ceiling — the measured worst case is 85ms, so there is a lot of headroom in 2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stop handling by waiting briefly for the assistant’s closing text to appear in the transcript before generating notification status.
  * Added bounded “transcript settling” polling that re-analyzes only while the transcript is still changing, including correct notification text for tool turns and cases where prose and `tool_use` share a message.
  * Ensured a no-wait fast path when verdict settles/unknown and text notifications are disabled.

* **Tests**
  * Expanded regression coverage for settling wait behavior, bounded termination, elapsed-time reparse costs, and multiple tool/text transcript edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
