### PR TITLE
fix(summary): recognise sentence boundaries outside ASCII

### DIFF
--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -127,7 +127,7 @@ func generateQuestionBody(messages []jsonl.Message) string {
 	// Strategy A: Find texts with "?" and prioritize short ones
 	var questionTexts []string
 	for i := len(texts) - 1; i >= 0; i-- {
-		if strings.Contains(texts[i], "?") {
+		if containsQuestionMark(texts[i]) {
 			questionTexts = append(questionTexts, texts[i])
 		}
 	}
@@ -455,6 +455,36 @@ func buildActionsString(toolCounts map[string]int, duration string) string {
 
 // Helper functions
 
+// isNonASCIISentenceEnd reports whether r ends a sentence in a script that does not
+// use the ASCII period. These also do not put a space after the terminator, which is
+// why the ASCII matching below — built around ". ", "! " and "? " — cannot see them.
+//
+//	U+3002 。 ideographic full stop       Chinese, Japanese
+//	U+FF01 ！ fullwidth exclamation mark  Chinese, Japanese
+//	U+FF1F ？ fullwidth question mark     Chinese, Japanese
+//	U+FF0E ． fullwidth full stop         occasionally used in CJK text
+//	U+0964 । danda                        Hindi and other Devanagari scripts
+//	U+0965 ॥ double danda                 Devanagari
+//	U+061F ؟ Arabic question mark         Arabic, Persian, Urdu
+//	U+06D4 ۔ Arabic full stop             Urdu
+//
+// U+3001 、 is deliberately absent: it is a comma, not a sentence end. Korean is not
+// listed because it terminates sentences with an ASCII period and a space, so it
+// already works; Thai has no sentence-ending punctuation at all and cannot be helped
+// by any character list.
+func isNonASCIISentenceEnd(r rune) bool {
+	switch r {
+	case '。', '！', '？', '．', '।', '॥', '؟', '۔':
+		return true
+	}
+	return false
+}
+
+// containsQuestionMark reports whether text holds a question mark in any script.
+func containsQuestionMark(text string) bool {
+	return strings.ContainsAny(text, "?？؟")
+}
+
 func extractFirstSentence(text string) string {
 	// Find first sentence (ending with . ! or ?)
 	// If first sentence is too short (< 20 chars), try to include second sentence too
@@ -466,7 +496,7 @@ func extractFirstSentence(text string) string {
 	runes := []rune(text)
 
 	for i, char := range runes {
-		if char == '.' || char == '!' || char == '?' {
+		if char == '.' || char == '!' || char == '?' || isNonASCIISentenceEnd(char) {
 			// For dots, check if this is really end of sentence:
 			// - Must be followed by space + uppercase letter, or end of string
 			// - Should not be preceded by a digit (to avoid "v1.6.0")
@@ -568,6 +598,17 @@ func truncateText(text string, maxLen int) string {
 		}
 		if lastSentenceEnd >= 0 {
 			break // Found a suitable sentence, no need to check other enders
+		}
+	}
+
+	// Scripts whose terminator is not followed by a space are invisible to the pair
+	// search above, so scan runes for one. Runes matter here: the search above indexes
+	// bytes, which in a multibyte script would land mid-character.
+	if lastSentenceEnd < 0 {
+		for i, r := range runes[:maxLen] {
+			if i > maxLen/3 && isNonASCIISentenceEnd(r) {
+				return strings.TrimSpace(string(runes[:i+1]))
+			}
 		}
 	}
 

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -521,7 +521,15 @@ func extractFirstSentence(text string) string {
 				sentences = append(sentences, sentence)
 				currentStart = i + 1
 
-				// Calculate total length so far
+				// Calculate total length so far.
+				//
+				// This is a byte count, so the two thresholds below land differently
+				// per script: 20 bytes is 20 characters of Latin text but roughly 7
+				// of a three-byte script. Left as is deliberately — the limits exist
+				// to judge whether one sentence carries enough for a notification,
+				// and a denser script needs fewer characters to say as much. Counting
+				// runes here would triple the effective minimum for those scripts and
+				// staple a second sentence onto bodies that already read well.
 				totalLength := len(strings.Join(sentences, " "))
 
 				// If we have at least one sentence and either:

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -1822,3 +1822,146 @@ func TestGenerateFromMessagesStructured_EmptyMessages(t *testing.T) {
 		t.Errorf("actions = %q, want empty for empty messages", actions)
 	}
 }
+
+// === Sentence boundaries outside ASCII ===
+
+// TestExtractFirstSentence_NonASCIITerminators covers scripts whose sentence
+// terminator is not an ASCII period. The split is not "CJK vs the rest": Korean
+// terminates with an ASCII period and a space and always worked, while Devanagari
+// does not and did not.
+func TestExtractFirstSentence_NonASCIITerminators(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected string
+	}{
+		{
+			name:     "Chinese ideographic full stop",
+			text:     "把音频后端重写成了 miniaudio 实现。之前的做法是在 Linux 上调用 aplay，没有音量控制。现在全部改成进程内解码。",
+			expected: "把音频后端重写成了 miniaudio 实现。",
+		},
+		{
+			name:     "Japanese ideographic full stop",
+			text:     "オーディオバックエンドを miniaudio で書き直しました。以前は aplay を呼び出していたため、音量調整もできませんでした。現在はプロセス内でデコードしています。",
+			expected: "オーディオバックエンドを miniaudio で書き直しました。",
+		},
+		{
+			name:     "Hindi danda",
+			text:     "ऑडियो बैकएंड को miniaudio से फिर से लिखा गया। पिछला कार्यान्वयन aplay को कॉल करता था। अब सब कुछ डिकोड होता है।",
+			expected: "ऑडियो बैकएंड को miniaudio से फिर से लिखा गया।",
+		},
+		{
+			name:     "Fullwidth question mark",
+			text:     "这个方案你觉得可行吗？如果可行我就按这个思路继续往下写，把剩下的部分补完。",
+			expected: "这个方案你觉得可行吗？",
+		},
+		{
+			name:     "Fullwidth exclamation mark",
+			text:     "全部测试都通过了！接下来我会把改动整理成一个提交，然后推送到远端分支上面去。",
+			expected: "全部测试都通过了！",
+		},
+		{
+			name:     "Arabic question mark",
+			text:     "هل تريد أن أكمل بهذه الطريقة؟ سوف أقوم بكتابة بقية الكود ثم أرسل النتيجة إليك لاحقا.",
+			expected: "هل تريد أن أكمل بهذه الطريقة؟",
+		},
+		{
+			name: "Ideographic comma is not a sentence end",
+			// 、 separates clauses; only the trailing 。 ends the sentence.
+			text:     "读取了配置、解析了参数、初始化了播放器。然后开始播放音频文件。",
+			expected: "读取了配置、解析了参数、初始化了播放器。",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractFirstSentence(tt.text); got != tt.expected {
+				t.Errorf("extractFirstSentence() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestExtractFirstSentence_AlreadyWorkingScripts pins the scripts that terminate
+// with an ASCII period plus a space, so the non-ASCII additions cannot regress them.
+func TestExtractFirstSentence_AlreadyWorkingScripts(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected string
+	}{
+		{
+			name:     "English",
+			text:     "Rewrote the audio backend to use miniaudio. The previous implementation shelled out to aplay on Linux. Now everything decodes in process.",
+			expected: "Rewrote the audio backend to use miniaudio.",
+		},
+		{
+			name:     "Russian",
+			text:     "Переписал аудио-бэкенд на miniaudio. Прежняя реализация вызывала aplay в Linux. Теперь всё декодируется внутри процесса.",
+			expected: "Переписал аудио-бэкенд на miniaudio.",
+		},
+		{
+			name:     "Korean",
+			text:     "오디오 백엔드를 miniaudio로 다시 작성했습니다. 이전에는 aplay를 호출했습니다. 이제는 프로세스 내에서 디코딩됩니다.",
+			expected: "오디오 백엔드를 miniaudio로 다시 작성했습니다.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractFirstSentence(tt.text); got != tt.expected {
+				t.Errorf("extractFirstSentence() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestExtractFirstSentence_ThaiFallsBackByDesign documents a limit rather than a
+// bug: Thai separates sentences with spaces and has no terminating punctuation, so
+// no character list can help. It falls back to the leading-100-runes behaviour.
+func TestExtractFirstSentence_ThaiFallsBackByDesign(t *testing.T) {
+	thai := "เขียนแบ็กเอนด์เสียงใหม่โดยใช้ miniaudio การใช้งานก่อนหน้านี้เรียก aplay บนลินุกซ์และ afplay บนแมค ซึ่งหมายความว่าไม่มีการควบคุมระดับเสียง ตอนนี้ทุกอย่างถอดรหัสภายในกระบวนการ"
+
+	got := extractFirstSentence(thai)
+	if n := len([]rune(got)); n != 100 {
+		t.Errorf("expected the 100-rune fallback for Thai, got %d runes", n)
+	}
+}
+
+func TestContainsQuestionMark(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"ASCII question mark", "Which database should we use?", true},
+		{"Fullwidth question mark", "我们应该用哪个数据库？", true},
+		{"Arabic question mark", "أي قاعدة بيانات نستخدم؟", true},
+		{"No question mark", "已经全部改完了。", false},
+		{"Ideographic full stop only", "这是一句陈述。", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsQuestionMark(tt.text); got != tt.want {
+				t.Errorf("containsQuestionMark(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTruncateText_NonASCIISentenceBoundary covers the other half: a terminator with
+// no space after it is invisible to the ". " style pair search.
+func TestTruncateText_NonASCIISentenceBoundary(t *testing.T) {
+	// Two sentences; the first ends past maxLen/3 so it is a usable cut point.
+	text := "先把音频后端整个重写了一遍，改用 miniaudio 来做解码和播放。剩下的部分包括音量控制、设备枚举以及跨平台的行为一致性，都会在后续的提交里面继续补完。"
+
+	got := truncateText(text, 60)
+	want := "先把音频后端整个重写了一遍，改用 miniaudio 来做解码和播放。"
+	if got != want {
+		t.Errorf("truncateText() = %q, want %q", got, want)
+	}
+	if strings.HasSuffix(got, "...") {
+		t.Error("should cut at the sentence boundary, not fall back to word truncation")
+	}
+}

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -1928,6 +1928,9 @@ func TestExtractFirstSentence_ThaiFallsBackByDesign(t *testing.T) {
 	}
 }
 
+// TestContainsQuestionMark covers the detection that decides whether an assistant
+// message reads as a question. Testing for an ASCII '?' alone missed every script
+// that asks with its own mark.
 func TestContainsQuestionMark(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

Sentence extraction and truncation accept only ASCII terminators, so a notification body written in a script that ends sentences with its own punctuation is cut at a fixed rune count instead of at the end of a sentence.

- `extractFirstSentence` tests for `.`, `!` and `?`
- `truncateText` searches for `". "`, `"! "` and `"? "` — a terminator followed by a space

A script that terminates with its own character, and puts no space after it, matches neither, so both fall through to their length-based fallbacks.

## The dividing line is the punctuation convention, not the script family

Measured by running the same four-sentence text through `GenerateFromMessagesStructured` in eight languages:

| | languages | convention |
|---|---|---|
| works | English, German, Russian | ASCII terminator + space |
| works | **Korean** | ASCII terminator + space — CJK, but unaffected |
| works | Arabic | ASCII period in practice |
| broken | Chinese, Japanese | `U+3002 。` with no space |
| broken | **Hindi** | `U+0964 ।` with no space — not CJK, but affected |

Korean and Hindi are the useful rows: membership in the CJK block predicts nothing here, which is why the fix is keyed on the terminator rather than on a script range.

One affected body of 198 runes was emitted as 100 runes severed mid-word, despite containing four sentence terminators:

```
before   已经把音频后端整个重写完成了。原来的实现是在 Linux 上直接调用 aplay、在 macOS 上调用
         afplay，这导致既没有音量控制也没办法选择输出设备。现在全部改成进程内解码，走 gopxl
after    已经把音频后端整个重写完成了。
```

## Fix

Accept the terminators those scripts use, and match them by scanning runes rather than searching for byte pairs — the existing search indexes bytes, which in a multibyte script would land mid-character.

The ASCII path is untouched, including its version-number guards (`v1.6.0`, `1.5`, abbreviations), so existing output is unchanged. The new matching only runs where the old code had already given up.

`U+3001 、` is deliberately excluded: it is a comma. Accepting it would split a clause list such as `读取了配置、解析了参数、初始化了播放器。` into three sentences. There is a test for that.

Question detection had the same defect: it tested for an ASCII `?`, so a question ending in `？` or `؟` was never recognised as a question at all.

## Thai is out of reach

Thai separates sentences with spaces and has no terminating punctuation, so no character list helps. `TestExtractFirstSentence_ThaiFallsBackByDesign` pins the fallback so the behaviour reads as a known limit rather than an oversight.

## Relationship to #10

[#10](https://github.com/777genius/claude-notifications-go/pull/10) touched the same
two functions in December, switching their length checks and slicing from bytes to
runes so multibyte text is not cut mid-character.

That fixed *how the text is measured*. This fixes *what is looked for*: the
terminator set was never widened, so a script whose sentences end in `。` or `।`
still finds no boundary and still falls through to the length-based path. After #10
it falls through neatly, on a character boundary, which is why the symptom reads as
a clean truncation rather than mojibake.

The gap survived #10 because its new cases used Greek and Russian — multibyte
*characters*, but ASCII *punctuation*. Nothing exercised a terminator outside ASCII.

## Testing

15 cases; 8 of them fail without the fix.

- `TestExtractFirstSentence_NonASCIITerminators` — ideographic full stop, danda, fullwidth `！`/`？`, Arabic `؟`, and the ideographic comma that must *not* split
- `TestExtractFirstSentence_AlreadyWorkingScripts` — English, Russian and Korean pinned so the additions cannot regress them
- `TestContainsQuestionMark`, `TestTruncateText_NonASCIISentenceBoundary`

Verified end-to-end by feeding one transcript to the released v1.40.1 binary and to this build through `handle-hook Stop`; the before/after above is that comparison.

- `go test ./...` — all packages pass
- `go test -race ./internal/summary/` — pass
- `golangci-lint run` (v2, repo config) — 0 issues

## Note for review

The terminator list is a deliberate judgement call, documented per code point at `isNonASCIISentenceEnd`. Ethiopic `።` and Armenian `։` follow the same pattern and would be one-line additions — I left out what I had no way to sanity-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved question detection to recognize ASCII, fullwidth, and Arabic/non-ASCII question marks.
  * Enhanced sentence splitting and text shortening to correctly handle non-Latin sentence-ending punctuation.
  * Preserved intended fallback behavior when no sentence terminator is present (including Thai).
* **Tests**
  * Added unit tests for non-ASCII sentence boundaries and question-mark variants, with regression coverage for scripts that already worked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
