### PR TITLE
fix(daemon): detect Claude Code's VS Code extension as VS Code

### DIFF
--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -232,12 +232,23 @@ func GetSearchTermWithFolder(terminalName, folderName string) string {
 
 // GetTerminalName detects the current terminal from environment variables.
 func GetTerminalName() string {
+	// Claude Code's VS Code extension runs inside the extension host, so there is no
+	// terminal to detect and every check below is answering the wrong question. Worse,
+	// they answer it confidently: the extension host inherits the environment of
+	// whatever launched VS Code, so a TERM_PROGRAM or KONSOLE_VERSION left over from
+	// that terminal names a window the session has nothing to do with. Settle it here,
+	// before anything inherited gets a chance to speak.
+	if os.Getenv("CLAUDE_CODE_ENTRYPOINT") == "claude-vscode" {
+		return "Code"
+	}
+
 	// Try TERM_PROGRAM first (set by many terminals)
 	if termProg := os.Getenv("TERM_PROGRAM"); termProg != "" {
 		return termProg
 	}
 
-	// Check VS Code indicators
+	// Check VS Code indicators (integrated terminal: shell integration injects
+	// VSCODE_INJECTION, the git extension exports VSCODE_GIT_IPC_HANDLE)
 	if os.Getenv("VSCODE_INJECTION") != "" || os.Getenv("VSCODE_GIT_IPC_HANDLE") != "" {
 		return "Code"
 	}

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -230,15 +230,23 @@ func GetSearchTermWithFolder(terminalName, folderName string) string {
 	return GetSearchTerm(terminalName)
 }
 
+// isVSCodeExtensionHost reports whether Claude Code is running as its VS Code
+// extension rather than inside a terminal.
+//
+// The extension host inherits the environment of whatever launched VS Code, so every
+// variable describing a terminal survives into a session that has no terminal at all.
+// CLAUDE_CODE_ENTRYPOINT is set by Claude Code itself and says where it is running,
+// which makes it the only one of them worth believing.
+func isVSCodeExtensionHost() bool {
+	return os.Getenv("CLAUDE_CODE_ENTRYPOINT") == "claude-vscode"
+}
+
 // GetTerminalName detects the current terminal from environment variables.
 func GetTerminalName() string {
-	// Claude Code's VS Code extension runs inside the extension host, so there is no
-	// terminal to detect and every check below is answering the wrong question. Worse,
-	// they answer it confidently: the extension host inherits the environment of
-	// whatever launched VS Code, so a TERM_PROGRAM or KONSOLE_VERSION left over from
-	// that terminal names a window the session has nothing to do with. Settle it here,
-	// before anything inherited gets a chance to speak.
-	if os.Getenv("CLAUDE_CODE_ENTRYPOINT") == "claude-vscode" {
+	// Answer before anything inherited gets a chance to speak: a TERM_PROGRAM or
+	// KONSOLE_VERSION left over from the terminal that launched VS Code names a window
+	// this session has nothing to do with.
+	if isVSCodeExtensionHost() {
 		return "Code"
 	}
 
@@ -275,6 +283,13 @@ func GetTerminalName() string {
 // GetX11WindowID returns the current terminal window's X11 window ID when available.
 // It is captured in the hook process and later used by the daemon for exact focus on X11.
 func GetX11WindowID() string {
+	// WINDOWID is inherited exactly like the terminal markers are, and it outranks
+	// them: TryFocusWithHints activates a window ID before it consults anything else.
+	// Left in place, an extension host launched from an X11 terminal would raise that
+	// terminal however confidently GetTerminalName says "Code".
+	if isVSCodeExtensionHost() {
+		return ""
+	}
 	return strings.TrimSpace(os.Getenv("WINDOWID"))
 }
 

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -821,3 +821,34 @@ func TestGetTerminalName_CLIEntrypointDefersToTerminal(t *testing.T) {
 		t.Errorf("GetTerminalName() = %q, want %q", got, "konsole")
 	}
 }
+
+// TestGetX11WindowID_VSCodeExtensionDropsInheritedID covers the window ID the
+// extension host inherits from an X11 terminal. It outranks the terminal name in
+// TryFocusWithHints, so leaving it in place would raise that terminal no matter what
+// GetTerminalName reports.
+func TestGetX11WindowID_VSCodeExtensionDropsInheritedID(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("CLAUDE_CODE_ENTRYPOINT", "claude-vscode")
+	os.Setenv("WINDOWID", "96249407204176")
+
+	if got := GetX11WindowID(); got != "" {
+		t.Errorf("GetX11WindowID() = %q, want empty for the extension host", got)
+	}
+}
+
+// TestGetX11WindowID_TerminalKeepsItsWindow pins the other direction: a terminal
+// session owns the window WINDOWID points at, and exact-ID focus is the best method
+// available on X11.
+func TestGetX11WindowID_TerminalKeepsItsWindow(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+	os.Setenv("WINDOWID", "96249407204176")
+
+	if got := GetX11WindowID(); got != "96249407204176" {
+		t.Errorf("GetX11WindowID() = %q, want the inherited window ID", got)
+	}
+}

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -11,6 +11,11 @@ import (
 func saveTerminalEnv(t *testing.T) func() {
 	t.Helper()
 	vars := []string{
+		// Set whenever the suite is run from Claude Code's own VS Code extension, and
+		// GetTerminalName now answers on it before anything else. Leaving it in place
+		// would make every case below detect "Code" — passing in CI, failing for
+		// anyone running the tests from the extension.
+		"CLAUDE_CODE_ENTRYPOINT",
 		"TERM_PROGRAM",
 		"VSCODE_INJECTION",
 		"VSCODE_GIT_IPC_HANDLE",
@@ -755,5 +760,64 @@ func TestMappingConsistency_CommonTerminals(t *testing.T) {
 		if r := GetSearchTerm(term); r == "" {
 			t.Errorf("GetSearchTerm(%q) returned empty", term)
 		}
+	}
+}
+
+// TestGetTerminalName_VSCodeExtension covers Claude Code running as the VS Code
+// extension rather than in a terminal. The extension host inherits the environment
+// of whatever launched VS Code, so terminal markers from that launcher are present
+// and wrong: the session belongs to no terminal at all.
+func TestGetTerminalName_VSCodeExtension(t *testing.T) {
+	tests := []struct {
+		name     string
+		leftover map[string]string
+	}{
+		{
+			name:     "nothing inherited",
+			leftover: nil,
+		},
+		{
+			name:     "launched from Konsole",
+			leftover: map[string]string{"KONSOLE_VERSION": "251203", "KONSOLE_DBUS_SESSION": "/Sessions/1"},
+		},
+		{
+			name:     "launched from a terminal that sets TERM_PROGRAM",
+			leftover: map[string]string{"TERM_PROGRAM": "ghostty"},
+		},
+		{
+			name:     "launched from GNOME Terminal",
+			leftover: map[string]string{"GNOME_TERMINAL_SCREEN": "/org/gnome/Terminal/screen/x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := saveTerminalEnv(t)
+			defer restore()
+
+			os.Setenv("CLAUDE_CODE_ENTRYPOINT", "claude-vscode")
+			for k, v := range tt.leftover {
+				os.Setenv(k, v)
+			}
+
+			if got := GetTerminalName(); got != "Code" {
+				t.Errorf("GetTerminalName() = %q, want %q", got, "Code")
+			}
+		})
+	}
+}
+
+// TestGetTerminalName_CLIEntrypointDefersToTerminal pins the other direction: the
+// CLI running inside a terminal is still that terminal, and the entrypoint check
+// must not swallow it.
+func TestGetTerminalName_CLIEntrypointDefersToTerminal(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+	os.Setenv("KONSOLE_VERSION", "251203")
+
+	if got := GetTerminalName(); got != "konsole" {
+		t.Errorf("GetTerminalName() = %q, want %q", got, "konsole")
 	}
 }

--- a/internal/notifier/focus_linux.go
+++ b/internal/notifier/focus_linux.go
@@ -4,11 +4,12 @@ package notifier
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/777genius/claude-notifications/internal/daemon"
 )
 
 // activeWindowQueryTimeout bounds the xdotool call so a stalled subprocess can
@@ -23,15 +24,20 @@ var activeWindowID = defaultActiveWindowID
 //
 // It compares the window manager's active window (_NET_ACTIVE_WINDOW, read via
 // xdotool) against $WINDOWID, which X11 terminals export for their own window.
-// When $WINDOWID is unset - typically under Wayland, where there is no portable
-// active-window query - focus is treated as unknown and the notification is
-// delivered. Class-based matching is intentionally avoided: two terminal windows
+// When no window ID is available - typically under Wayland, where there is no
+// portable active-window query - focus is treated as unknown and the notification
+// is delivered. Class-based matching is intentionally avoided: two terminal windows
 // share a class, so it cannot tell "the window Claude runs in" from "another
 // terminal", and a false match would swallow the notification.
+//
+// The ID comes from daemon.GetX11WindowID rather than the environment directly, so
+// the VS Code extension host does not compare against a window it merely inherited:
+// the launching terminal being focused would otherwise read as "we are focused" and
+// swallow the notification.
 func terminalHasFocus(_, _ string) bool {
-	ours, ok := parseWindowID(os.Getenv("WINDOWID"))
+	ours, ok := parseWindowID(daemon.GetX11WindowID())
 	if !ok {
-		return false // Wayland, or a terminal that does not export WINDOWID
+		return false // Wayland, the extension host, or a terminal without WINDOWID
 	}
 	activeRaw, err := activeWindowID()
 	if err != nil {

--- a/internal/notifier/focus_linux_test.go
+++ b/internal/notifier/focus_linux_test.go
@@ -34,6 +34,12 @@ func TestTerminalHasFocus_Linux(t *testing.T) {
 	restore := activeWindowID
 	defer func() { activeWindowID = restore }()
 
+	// Set whenever the suite runs from Claude Code's own VS Code extension, where the
+	// window ID is now deliberately dropped. Left in place, every case below would see
+	// no window and report unfocused — green in CI, red for anyone running the tests
+	// from the extension.
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "")
+
 	t.Run("focused when active window matches WINDOWID", func(t *testing.T) {
 		t.Setenv("WINDOWID", "0x1e00009")
 		activeWindowID = func() (string, error) { return "31457289", nil } // == 0x1e00009
@@ -65,4 +71,40 @@ func TestTerminalHasFocus_Linux(t *testing.T) {
 			t.Error("expected no focus (deliver) when the query fails")
 		}
 	})
+}
+
+// TestTerminalHasFocus_VSCodeExtensionIgnoresInheritedWindow covers the other
+// consumer of WINDOWID. Under the extension host the variable names the terminal
+// that launched VS Code, so comparing against it would report "focused" whenever
+// that terminal is in front — and notifyOnlyWhenUnfocused would then swallow a
+// notification the user never saw.
+func TestTerminalHasFocus_VSCodeExtensionIgnoresInheritedWindow(t *testing.T) {
+	restore := activeWindowID
+	defer func() { activeWindowID = restore }()
+
+	// The inherited window is the active one: the trap this guards against.
+	activeWindowID = func() (string, error) { return "96249407204176", nil }
+
+	t.Setenv("WINDOWID", "96249407204176")
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "claude-vscode")
+
+	if terminalHasFocus("session", "/project") {
+		t.Error("the extension host must not treat an inherited window as its own")
+	}
+}
+
+// TestTerminalHasFocus_TerminalStillMatchesItsOwnWindow pins the case the check
+// exists for: a terminal session comparing against the window it really owns.
+func TestTerminalHasFocus_TerminalStillMatchesItsOwnWindow(t *testing.T) {
+	restore := activeWindowID
+	defer func() { activeWindowID = restore }()
+
+	activeWindowID = func() (string, error) { return "96249407204176", nil }
+
+	t.Setenv("WINDOWID", "96249407204176")
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+
+	if !terminalHasFocus("session", "/project") {
+		t.Error("a terminal owning the active window should report focused")
+	}
 }


### PR DESCRIPTION
## Problem

When Claude Code runs as its VS Code extension there is no terminal to detect, but `GetTerminalName` keeps looking for one — and finds whichever terminal happened to launch VS Code. The extension host inherits that terminal's entire environment, so click-to-focus raises it instead of the editor.

Measured in an extension host on Plasma:

```
TERM_PROGRAM            <unset>
VSCODE_INJECTION        <unset>
VSCODE_GIT_IPC_HANDLE   <unset>
KONSOLE_VERSION         251203        ← inherited from the Konsole that started VS Code
CLAUDE_CODE_ENTRYPOINT  claude-vscode
```

`GetTerminalName` walks past the first three and answers `konsole`. Launch VS Code from a terminal that sets `TERM_PROGRAM` and it answers that instead; launch it from the desktop and it falls through to the generic `Terminal`. Every one of those names a window the session has nothing to do with.

Neither VS Code marker already checked for helps: `VSCODE_INJECTION` comes from shell integration and `VSCODE_GIT_IPC_HANDLE` from the git extension, so both belong to the **integrated terminal** and neither is set in the extension host.

## Fix

`CLAUDE_CODE_ENTRYPOINT` says where Claude Code is running, so answer on it before any inherited variable gets a chance to speak.

Placement matters. It has to come before the `TERM_PROGRAM` check rather than beside the other VS Code markers, because `TERM_PROGRAM` is one of the values that leaks in.

The CLI is unaffected: its entrypoint is not `claude-vscode`, so a terminal running it is still detected as that terminal — pinned by a test.

## A test-isolation bug this turned up

`saveTerminalEnv` clears the terminal variables for each case but did not know about `CLAUDE_CODE_ENTRYPOINT`. That variable is set whenever the suite runs from the extension itself, which is to say on the machine most likely to be working on this file. With the new check in place and the variable left standing, six `GetTerminalName` cases detect `Code` regardless of what they set up:

```
GetTerminalName() with TERM_PROGRAM=kitty = "Code", want "kitty"
GetTerminalName() fallback = "Code", want "Terminal"
GetTerminalName() with GNOME_TERMINAL_SCREEN = "Code", want "gnome-terminal"
…
```

Green in CI, red locally. Adding it to the cleared list fixes that.

## Testing

- `TestGetTerminalName_VSCodeExtension` — four inherited environments (nothing, Konsole, a `TERM_PROGRAM` setter, GNOME Terminal), all detecting `Code`
- `TestGetTerminalName_CLIEntrypointDefersToTerminal` — the CLI in Konsole is still `konsole`

Verified end-to-end on Plasma 6 Wayland with the click-to-focus path: before the change a notification raised the wrong window, after it the VS Code window.

- `make test-race` — 21 packages pass
- `make lint` — clean, `go fmt` rewrote nothing
- `golangci-lint run` (v2, repo config) — 0 issues

## Note

Independent of #127, which makes click-to-focus work on KDE at all. This change decides *which* window to raise; that one decides *how*. They touch different files and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal name detection when running through the Claude Code VS Code extension host.
  * Prevents inherited `WINDOWID` values from being treated as the terminal’s own window on Linux notifications, yielding correct focus detection (including Wayland/unknown cases).
  * Maintains expected behavior for standard CLI sessions.
* **Tests**
  * Expanded coverage for Linux focus detection and terminal/window ID handling across VS Code extension and CLI entrypoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->