### PR TITLE
feat: label notifications with Claude Code's session title (sessionNameSource)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Notifications can be labeled with Claude Code's own session title** - set `notifications.sessionNameSource: "aiTitle"` to replace the generated `bold 06ddb8f7` label with the session name Claude shows on the terminal tab, so parallel sessions in one folder are distinguishable. Falls back to the generated label until Claude has named the session; default behavior is unchanged.
+
 ## [1.40.1] - 2026-07-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Edit the config file directly:
     "respectJudgeMode": true,
     "notifyOnlyWhenUnfocused": false,
     "notifyDelaySeconds": 0,
+    "sessionNameSource": "generated",
     "suppressFilters": [
       {
         "name": "Suppress ClaudeProbe completions (remote-control)",
@@ -280,6 +281,7 @@ Edit the config file directly:
 | `respectJudgeMode` | `true` | Honor `CLAUDE_HOOK_JUDGE_MODE=true` env var to suppress notifications |
 | `notifyOnlyWhenUnfocused` | `false` | Skip the desktop notification only when the focused terminal window can be matched to the current Claude Code session. Best-effort per platform; if focus can't be determined the notification is still shown. |
 | `notifyDelaySeconds` | `0` | Wait N seconds before delivering a desktop notification (capped at 25s by the hook timeout). With `notifyOnlyWhenUnfocused`, focus is re-checked after the wait. Webhooks are unaffected. |
+| `sessionNameSource` | `"generated"` | How the session is labeled in the message prefix. `"generated"` uses a word plus the session id (`bold 06ddb8f7`). `"aiTitle"` uses Claude Code's own session title — the name it shows on the terminal tab (`Fix the flaky auth test`) — which tells apart several sessions running in one folder; it falls back to the generated label until Claude has named the session. Note that the label also reaches webhooks. |
 | `suppressQuestionAfterTaskCompleteSeconds` | `12` | Suppress question notifications for N seconds after task complete |
 | `suppressQuestionAfterAnyNotificationSeconds` | `7` | Suppress question notifications for N seconds after any notification |
 | `suppressFilters` | `[]` | Array of rules to suppress notifications by status, git branch, and/or folder. Each rule is an AND of its fields; omitted fields match any value. Set `gitBranch` to `""` to match sessions outside git repos. |
@@ -304,6 +306,27 @@ You can also override individual channels per status:
 `statuses.<name>.enabled` is still the master switch for both channels. Use
 `desktop.enabled` and `webhook.enabled` when you want one channel on and the
 other off for the same status.
+
+### Session Labels
+
+Every notification is prefixed with the session it came from: `[bold 06ddb8f7|main my-app] …`. That label is a word derived from the session id, which is stable but arbitrary — when several sessions run in the same folder and on the same branch, the label is the only thing telling them apart, and there's nothing to recognize.
+
+Set `sessionNameSource: "aiTitle"` to use Claude Code's own session title instead — the same name it shows on the terminal tab:
+
+```json
+{
+  "notifications": {
+    "sessionNameSource": "aiTitle"
+  }
+}
+```
+
+```
+[bold 06ddb8f7|main my-app] Added the retry path        <- "generated" (default)
+[Fix the flaky auth test|main my-app] Added the retry path   <- "aiTitle"
+```
+
+Claude names a session a little after it starts, and subagent transcripts often have no title at all, so the generated label is still used whenever no title exists. Titles are squeezed onto one line and capped at 60 characters. Since this label is also sent to webhooks, opting in means your session titles leave the machine.
 
 ### Focus-Aware & Delayed Notifications
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,14 +28,15 @@ type NotificationsConfig struct {
 	Webhook                                     WebhookConfig    `json:"webhook"`
 	SuppressQuestionAfterTaskCompleteSeconds    *int             `json:"suppressQuestionAfterTaskCompleteSeconds"`
 	SuppressQuestionAfterAnyNotificationSeconds *int             `json:"suppressQuestionAfterAnyNotificationSeconds"`
-	NotifyOnSubagentStop                        bool             `json:"notifyOnSubagentStop"`      // Send notifications when subagents (Task tool) complete, default: false. Requires suppressForSubagents=false to take effect.
-	SuppressForSubagents                        *bool            `json:"suppressForSubagents"`      // Suppress subagent (SubagentStop) notifications, and Stop notifications whose transcript_path is a subagent/teammate transcript; default: true. Overrides notifyOnSubagentStop.
-	NotifyOnTextResponse                        *bool            `json:"notifyOnTextResponse"`      // Send notifications for text-only responses (no tools), default: true
-	RespectJudgeMode                            *bool            `json:"respectJudgeMode"`          // Honor CLAUDE_HOOK_JUDGE_MODE=true env var to suppress notifications, default: true
-	SuppressFilters                             []SuppressFilter `json:"suppressFilters,omitempty"` // Rules for suppressing notifications by status/branch/folder
-	TeamMode                                    string           `json:"teamMode,omitempty"`        // Team mode: "always" (no suppression, default), "wait-all" (suppress lead, notify when all idle), "never" (silent in team mode)
-	NotifyOnlyWhenUnfocused                     *bool            `json:"notifyOnlyWhenUnfocused"`   // Suppress desktop notifications while the terminal window running Claude Code has OS focus, default: false
-	NotifyDelaySeconds                          *int             `json:"notifyDelaySeconds"`        // Wait N seconds before delivering a desktop notification (paired with notifyOnlyWhenUnfocused, it re-checks focus after the wait), default: 0
+	NotifyOnSubagentStop                        bool             `json:"notifyOnSubagentStop"`        // Send notifications when subagents (Task tool) complete, default: false. Requires suppressForSubagents=false to take effect.
+	SuppressForSubagents                        *bool            `json:"suppressForSubagents"`        // Suppress subagent (SubagentStop) notifications, and Stop notifications whose transcript_path is a subagent/teammate transcript; default: true. Overrides notifyOnSubagentStop.
+	NotifyOnTextResponse                        *bool            `json:"notifyOnTextResponse"`        // Send notifications for text-only responses (no tools), default: true
+	RespectJudgeMode                            *bool            `json:"respectJudgeMode"`            // Honor CLAUDE_HOOK_JUDGE_MODE=true env var to suppress notifications, default: true
+	SuppressFilters                             []SuppressFilter `json:"suppressFilters,omitempty"`   // Rules for suppressing notifications by status/branch/folder
+	TeamMode                                    string           `json:"teamMode,omitempty"`          // Team mode: "always" (no suppression, default), "wait-all" (suppress lead, notify when all idle), "never" (silent in team mode)
+	NotifyOnlyWhenUnfocused                     *bool            `json:"notifyOnlyWhenUnfocused"`     // Suppress desktop notifications while the terminal window running Claude Code has OS focus, default: false
+	NotifyDelaySeconds                          *int             `json:"notifyDelaySeconds"`          // Wait N seconds before delivering a desktop notification (paired with notifyOnlyWhenUnfocused, it re-checks focus after the wait), default: 0
+	SessionNameSource                           string           `json:"sessionNameSource,omitempty"` // Session label source: "generated" (word + session id prefix, default) or "aiTitle" (Claude Code's own session title, falling back to generated)
 }
 
 // DesktopConfig represents desktop notification settings
@@ -561,6 +562,12 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid teamMode %q (must be one of: always, wait-all, never)", c.Notifications.TeamMode)
 	}
 
+	// Validate sessionNameSource
+	validSessionNameSources := map[string]bool{"": true, "generated": true, "aiTitle": true}
+	if !validSessionNameSources[c.Notifications.SessionNameSource] {
+		return fmt.Errorf("invalid sessionNameSource %q (must be one of: generated, aiTitle)", c.Notifications.SessionNameSource)
+	}
+
 	// Validate suppress-filters
 	validStatuses := map[string]bool{
 		"task_complete":         true,
@@ -682,6 +689,15 @@ func (c *Config) GetTeamMode() string {
 	default:
 		return "always"
 	}
+}
+
+// GetSessionNameSource returns the session label source: "generated" (default)
+// or "aiTitle".
+func (c *Config) GetSessionNameSource() string {
+	if c.Notifications.SessionNameSource == "aiTitle" {
+		return "aiTitle"
+	}
+	return "generated"
 }
 
 // IsStatusEnabled returns true if notifications for this status are enabled

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1741,3 +1741,39 @@ func TestValidate_NegativeNotifyDelay(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "notifyDelaySeconds must be >= 0")
 }
+
+func TestGetSessionNameSource_DefaultsGenerated(t *testing.T) {
+	cfg := &Config{}
+	assert.Equal(t, "generated", cfg.GetSessionNameSource())
+
+	cfgExplicit := &Config{Notifications: NotificationsConfig{SessionNameSource: "generated"}}
+	assert.Equal(t, "generated", cfgExplicit.GetSessionNameSource())
+}
+
+func TestGetSessionNameSource_AiTitle(t *testing.T) {
+	cfg := &Config{Notifications: NotificationsConfig{SessionNameSource: "aiTitle"}}
+	assert.Equal(t, "aiTitle", cfg.GetSessionNameSource())
+}
+
+func TestGetSessionNameSource_UnknownFallsBackToGenerated(t *testing.T) {
+	// Validate rejects unknown values, but the getter is defensive
+	cfg := &Config{Notifications: NotificationsConfig{SessionNameSource: "tab-title"}}
+	assert.Equal(t, "generated", cfg.GetSessionNameSource())
+}
+
+func TestValidate_InvalidSessionNameSource(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Notifications.SessionNameSource = "tab-title"
+
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid sessionNameSource")
+}
+
+func TestValidate_ValidSessionNameSources(t *testing.T) {
+	for _, source := range []string{"", "generated", "aiTitle"} {
+		cfg := DefaultConfig()
+		cfg.Notifications.SessionNameSource = source
+		assert.NoError(t, cfg.Validate(), "source %q should be valid", source)
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -418,7 +418,7 @@ func (h *Handler) HandleHook(hookEvent string, input io.Reader) error {
 
 	// Send notifications
 	bench.Start("notify.send")
-	delivery := h.sendNotifications(status, body, actions, hookData.SessionID, hookData.CWD)
+	delivery := h.sendNotifications(status, body, actions, hookData.SessionID, h.resolveSessionName(&hookData, parsedMessages), hookData.CWD)
 	bench.Elapsed("notify.send")
 
 	if delivery.delivered() {
@@ -519,7 +519,9 @@ func (h *Handler) handleTeammateIdle(hookData *HookData) error {
 	status := analyzer.StatusTaskComplete
 	body := fmt.Sprintf("Team %q: all teammates finished work", hookData.TeamName)
 
-	h.sendNotifications(status, body, "", hookData.SessionID, hookData.CWD)
+	// Team notifications are not tied to one session's transcript, so they keep
+	// the generated label.
+	h.sendNotifications(status, body, "", hookData.SessionID, "", hookData.CWD)
 
 	logging.Debug("=== Hook completed: TeammateIdle (team notification sent) ===")
 	return nil
@@ -558,6 +560,37 @@ func (h *Handler) handleStopEvent(hookData *HookData) (analyzer.Status, []jsonl.
 	return status, messages, nil
 }
 
+// resolveSessionName returns the label identifying this session in the
+// notification prefix. With sessionNameSource="aiTitle" it prefers Claude Code's
+// own session title — the same name shown on the terminal tab — which tells
+// several sessions in one folder apart. Returns "" to mean "use the generated
+// label", which is also what happens when the session has no title yet.
+//
+// Already-parsed messages are reused when the caller has them (Stop events);
+// otherwise the transcript is scanned for ai-title lines alone, not fully parsed.
+func (h *Handler) resolveSessionName(hookData *HookData, messages []jsonl.Message) string {
+	if h.cfg.GetSessionNameSource() != "aiTitle" {
+		return ""
+	}
+
+	aiTitle := jsonl.LastAiTitle(messages)
+	if aiTitle == "" && hookData.TranscriptPath != "" && platform.FileExists(hookData.TranscriptPath) {
+		scanned, err := jsonl.LastAiTitleFromFile(hookData.TranscriptPath)
+		if err != nil {
+			logging.Warn("Failed to read session title from transcript: %v", err)
+		} else {
+			aiTitle = scanned
+		}
+	}
+
+	if aiTitle == "" {
+		logging.Debug("sessionNameSource=aiTitle but no title found, using generated label")
+		return ""
+	}
+
+	return sessionname.FromAiTitle(aiTitle, hookData.SessionID)
+}
+
 // generateMessage generates a notification body and action summary.
 // If messages are provided (from handleStopEvent), uses them directly to avoid re-reading the transcript.
 func (h *Handler) generateMessage(hookData *HookData, status analyzer.Status, messages []jsonl.Message) (body, actions string) {
@@ -591,13 +624,17 @@ func joinMessageParts(body, actions string) string {
 //
 // body is the summary text (no metadata prefix, no action segments).
 // actions is the formatted action summary (e.g. "📝 1 new  ▶ 2 cmds  ⏱ 41s") or "".
-func (h *Handler) sendNotifications(status analyzer.Status, body, actions, sessionID, cwd string) notificationDelivery {
+// sessionName labels the session in the message prefix; empty falls back to the
+// generated word-plus-id label.
+func (h *Handler) sendNotifications(status analyzer.Status, body, actions, sessionID, sessionName, cwd string) notificationDelivery {
 	// Add panic recovery to prevent notification failures from crashing the plugin
 	defer errorhandler.HandlePanic()
 
 	var delivery notificationDelivery
 
-	sessionName := sessionname.GenerateSessionLabel(sessionID)
+	if sessionName == "" {
+		sessionName = sessionname.GenerateSessionLabel(sessionID)
+	}
 	gitBranch := platform.GetGitBranch(cwd)
 	folderName := filepath.Base(cwd)
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/777genius/claude-notifications/internal/analyzer"
 	"github.com/777genius/claude-notifications/internal/config"
 	"github.com/777genius/claude-notifications/internal/dedup"
+	"github.com/777genius/claude-notifications/internal/sessionname"
 	"github.com/777genius/claude-notifications/internal/state"
 	"github.com/777genius/claude-notifications/internal/teamstate"
 	"github.com/777genius/claude-notifications/internal/webhook"
@@ -2393,4 +2394,117 @@ func TestHandler_Stop_NonTeamLead_NormalBehavior(t *testing.T) {
 func setupTeamStateManager(t *testing.T, homeDir string) *teamstate.Manager {
 	t.Helper()
 	return teamstate.NewManager(filepath.Join(homeDir, ".claude"))
+}
+
+// === Session label source tests ===
+
+func buildTranscriptWithAiTitle(aiTitle string) []jsonl.Message {
+	messages := buildTranscriptWithTools([]string{"Read", "Edit", "Write"}, 300)
+	return append(messages, jsonl.Message{Type: jsonl.TypeAiTitle, AiTitle: aiTitle})
+}
+
+func TestHandler_Stop_SessionNameFromAiTitle(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop:           config.DesktopConfig{Enabled: true},
+			SessionNameSource: "aiTitle",
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+	transcriptPath := createTempTranscript(t, buildTranscriptWithAiTitle("Fix the flaky auth test"))
+
+	hookData := buildHookDataJSON(HookData{
+		SessionID:      "test-session-ai-title",
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	})
+
+	if err := handler.HandleHook("Stop", hookData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	if !strings.Contains(mockNotif.lastCall().message, "[Fix the flaky auth test") {
+		t.Errorf("expected message to be labeled with the session title, got %q", mockNotif.lastCall().message)
+	}
+}
+
+func TestHandler_Stop_SessionNameFallsBackWithoutAiTitle(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop:           config.DesktopConfig{Enabled: true},
+			SessionNameSource: "aiTitle",
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+	// No ai-title entry: a session Claude has not named yet
+	transcriptPath := createTempTranscript(t, buildTranscriptWithTools([]string{"Read", "Edit", "Write"}, 300))
+
+	sessionID := "test-session-no-title"
+	hookData := buildHookDataJSON(HookData{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	})
+
+	if err := handler.HandleHook("Stop", hookData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	expected := "[" + sessionname.GenerateSessionLabel(sessionID)
+	if !strings.Contains(mockNotif.lastCall().message, expected) {
+		t.Errorf("expected generated label %q, got %q", expected, mockNotif.lastCall().message)
+	}
+}
+
+func TestHandler_Stop_SessionNameDefaultIgnoresAiTitle(t *testing.T) {
+	cfg := &config.Config{
+		Notifications: config.NotificationsConfig{
+			Desktop: config.DesktopConfig{Enabled: true},
+		},
+		Statuses: map[string]config.StatusInfo{
+			"task_complete": {Title: "Task Complete"},
+		},
+	}
+
+	handler, mockNotif, _ := newTestHandler(t, cfg)
+	transcriptPath := createTempTranscript(t, buildTranscriptWithAiTitle("Fix the flaky auth test"))
+
+	sessionID := "test-session-default-source"
+	hookData := buildHookDataJSON(HookData{
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+		CWD:            "/test",
+	})
+
+	if err := handler.HandleHook("Stop", hookData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mockNotif.wasCalled() {
+		t.Fatal("expected notification to be sent")
+	}
+
+	message := mockNotif.lastCall().message
+	if strings.Contains(message, "Fix the flaky auth test") {
+		t.Errorf("default source should not use the session title, got %q", message)
+	}
+	if !strings.Contains(message, "["+sessionname.GenerateSessionLabel(sessionID)) {
+		t.Errorf("expected generated label, got %q", message)
+	}
 }

--- a/internal/sessionname/sessionname.go
+++ b/internal/sessionname/sessionname.go
@@ -80,6 +80,48 @@ func GenerateSessionLabel(sessionID string) string {
 	return name + " " + prefix
 }
 
+// MaxAiTitleLength caps how much of a session title reaches a notification, so a
+// long title cannot crowd out the message body it is prefixed to.
+const MaxAiTitleLength = 60
+
+// FromAiTitle returns Claude Code's own session title as the session label,
+// falling back to GenerateSessionLabel when the session has no title yet (early
+// in a conversation, or on subagent transcripts).
+//
+// The title is squeezed onto one line and stripped of the characters that
+// delimit the notification's "[name|branch folder]" prefix, so a title can never
+// be mistaken for those fields.
+func FromAiTitle(aiTitle, sessionID string) string {
+	cleaned := sanitizeAiTitle(aiTitle)
+	if cleaned == "" {
+		return GenerateSessionLabel(sessionID)
+	}
+	return cleaned
+}
+
+// sanitizeAiTitle collapses whitespace, drops prefix delimiters, and truncates
+// to MaxAiTitleLength runes.
+func sanitizeAiTitle(aiTitle string) string {
+	replaced := strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t':
+			return ' '
+		case '[', ']', '|':
+			return -1
+		}
+		return r
+	}, aiTitle)
+
+	cleaned := strings.Join(strings.Fields(replaced), " ")
+
+	runes := []rune(cleaned)
+	if len(runes) > MaxAiTitleLength {
+		cleaned = strings.TrimSpace(string(runes[:MaxAiTitleLength]))
+	}
+
+	return cleaned
+}
+
 // hexToInt converts hex string to int (takes first 6 characters for safety)
 func hexToInt(hex string) int {
 	if len(hex) > 6 {

--- a/internal/sessionname/sessionname_test.go
+++ b/internal/sessionname/sessionname_test.go
@@ -1,7 +1,9 @@
 package sessionname
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -154,4 +156,69 @@ func TestHexToInt_PartiallyValid(t *testing.T) {
 	result := hexToInt("12z45")
 	assert.Equal(t, 0x12, result, "Should parse valid hex prefix '12'")
 	assert.Equal(t, 18, result)
+}
+
+func TestFromAiTitle(t *testing.T) {
+	sessionID := "06ddb8f7-1234-5678-9abc-def012345678"
+
+	tests := []struct {
+		name     string
+		aiTitle  string
+		expected string
+	}{
+		{
+			name:     "plain title is used as-is",
+			aiTitle:  "Fix the flaky auth test",
+			expected: "Fix the flaky auth test",
+		},
+		{
+			name:     "prefix delimiters are dropped",
+			aiTitle:  "Handle [brackets] and | pipes",
+			expected: "Handle brackets and pipes",
+		},
+		{
+			name:     "newlines and runs of whitespace collapse",
+			aiTitle:  "Multi\nline\ttitle   with   gaps",
+			expected: "Multi line title with gaps",
+		},
+		{
+			name:     "long title is truncated",
+			aiTitle:  strings.Repeat("a", MaxAiTitleLength+20),
+			expected: strings.Repeat("a", MaxAiTitleLength),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, FromAiTitle(tt.aiTitle, sessionID))
+		})
+	}
+}
+
+func TestFromAiTitleFallsBackToGeneratedLabel(t *testing.T) {
+	sessionID := "06ddb8f7-1234-5678-9abc-def012345678"
+	generated := GenerateSessionLabel(sessionID)
+
+	tests := []struct {
+		name    string
+		aiTitle string
+	}{
+		{"empty title", ""},
+		{"whitespace only", "   \n\t "},
+		{"delimiters only", "[|]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, generated, FromAiTitle(tt.aiTitle, sessionID))
+		})
+	}
+}
+
+func TestFromAiTitleTruncatesOnRuneBoundary(t *testing.T) {
+	// Multi-byte runes must not be cut mid-rune
+	title := strings.Repeat("日", MaxAiTitleLength+5)
+	result := FromAiTitle(title, "06ddb8f7-1234-5678-9abc-def012345678")
+	assert.Equal(t, MaxAiTitleLength, len([]rune(result)))
+	assert.True(t, utf8.ValidString(result))
 }

--- a/pkg/jsonl/jsonl.go
+++ b/pkg/jsonl/jsonl.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+// TypeAiTitle is the transcript entry type Claude Code writes when it names a
+// session: {"type":"ai-title","aiTitle":"Fix the flaky auth test","sessionId":"..."}
+const TypeAiTitle = "ai-title"
+
 // Message represents a Claude Code transcript message
 type Message struct {
 	ParentUUID        string         `json:"parentUuid"`
@@ -17,6 +21,7 @@ type Message struct {
 	Timestamp         string         `json:"timestamp"`
 	IsApiErrorMessage bool           `json:"isApiErrorMessage,omitempty"`
 	Error             string         `json:"error,omitempty"`
+	AiTitle           string         `json:"aiTitle,omitempty"` // Set on TypeAiTitle entries only
 }
 
 // MessageContent represents the content of a message
@@ -129,6 +134,55 @@ func Parse(r io.Reader) ([]Message, error) {
 	}
 
 	return messages, nil
+}
+
+// LastAiTitle returns the most recent ai-title from already-parsed messages, or
+// "" when the session has not been named yet. Claude Code rewrites the title as
+// the conversation moves on, so the last entry wins.
+func LastAiTitle(messages []Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Type == TypeAiTitle && messages[i].AiTitle != "" {
+			return messages[i].AiTitle
+		}
+	}
+	return ""
+}
+
+// LastAiTitleFromFile returns the most recent ai-title in a transcript file.
+// Only lines that look like ai-title entries are unmarshalled, so this stays
+// cheap on multi-megabyte transcripts. Callers that already hold parsed
+// messages should use LastAiTitle instead.
+func LastAiTitleFromFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	marker := []byte(`"` + TypeAiTitle + `"`)
+	title := ""
+	reader := bufio.NewReaderSize(f, 64*1024)
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		line = bytes.TrimRight(line, "\r\n")
+		if bytes.Contains(line, marker) {
+			var msg Message
+			if jsonErr := json.Unmarshal(line, &msg); jsonErr == nil {
+				if msg.Type == TypeAiTitle && msg.AiTitle != "" {
+					title = msg.AiTitle
+				}
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", err
+		}
+	}
+
+	return title, nil
 }
 
 // GetLastApiErrorMessages returns the last N messages with isApiErrorMessage=true

--- a/pkg/jsonl/jsonl_test.go
+++ b/pkg/jsonl/jsonl_test.go
@@ -974,3 +974,85 @@ func TestMessageContent_MarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestLastAiTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonl    string
+		expected string
+	}{
+		{
+			name: "single title",
+			jsonl: `{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"ai-title","aiTitle":"Fix the flaky auth test","sessionId":"abc"}`,
+			expected: "Fix the flaky auth test",
+		},
+		{
+			name: "last title wins when Claude renames the session",
+			jsonl: `{"type":"ai-title","aiTitle":"First guess","sessionId":"abc"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+{"type":"ai-title","aiTitle":"What it turned into","sessionId":"abc"}`,
+			expected: "What it turned into",
+		},
+		{
+			name:     "no title yet",
+			jsonl:    `{"type":"user","message":{"role":"user","content":"hi"}}`,
+			expected: "",
+		},
+		{
+			name:     "empty title is ignored",
+			jsonl:    `{"type":"ai-title","aiTitle":"","sessionId":"abc"}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, err := Parse(strings.NewReader(tt.jsonl))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, LastAiTitle(messages))
+		})
+	}
+}
+
+func TestLastAiTitleEmptyMessages(t *testing.T) {
+	assert.Equal(t, "", LastAiTitle(nil))
+	assert.Equal(t, "", LastAiTitle([]Message{}))
+}
+
+func TestLastAiTitleFromFile(t *testing.T) {
+	content := `{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"ai-title","aiTitle":"First guess","sessionId":"abc"}
+not json at all
+{"type":"ai-title","aiTitle":"Make notifications click through","sessionId":"abc"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`
+
+	path := t.TempDir() + "/transcript.jsonl"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	title, err := LastAiTitleFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "Make notifications click through", title)
+}
+
+func TestLastAiTitleFromFileWithoutTitle(t *testing.T) {
+	path := t.TempDir() + "/transcript.jsonl"
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"user","message":{"role":"user","content":"hi"}}`), 0o600))
+
+	title, err := LastAiTitleFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "", title)
+}
+
+func TestLastAiTitleFromFileMissingFile(t *testing.T) {
+	_, err := LastAiTitleFromFile(t.TempDir() + "/does-not-exist.jsonl")
+	assert.Error(t, err)
+}
+
+func TestAiTitleRoundTrips(t *testing.T) {
+	line := `{"type":"ai-title","aiTitle":"Round trip","sessionId":"abc"}`
+	var msg Message
+	require.NoError(t, json.Unmarshal([]byte(line), &msg))
+	assert.Equal(t, TypeAiTitle, msg.Type)
+	assert.Equal(t, "Round trip", msg.AiTitle)
+}


### PR DESCRIPTION
## Problem

Every notification is prefixed with a session label: `[bold 06ddb8f7|main my-app] …`. The label comes from `sessionname.GenerateSessionLabel` — a word chosen deterministically from the session UUID, plus the id's first 8 chars.

It's stable, but there's nothing in it to recognize. When several sessions run in the same folder — same branch, same `folder` — the word is the *only* thing distinguishing the banners, so "which chat is this?" means opening tabs until you find the one that's waiting. And the mapping resets with every new session.

Meanwhile Claude Code already names each session and writes it to the transcript as an `ai-title` entry:

```json
{"type":"ai-title","aiTitle":"Fix the flaky auth test","sessionId":"…"}
```

That's the name it shows on the terminal tab, so it matches what the user is already looking at.

## Change

Adds `notifications.sessionNameSource`:

| value | label |
|---|---|
| `"generated"` (default, unchanged) | `[bold 06ddb8f7\|main my-app] Added the retry path` |
| `"aiTitle"` | `[Fix the flaky auth test\|main my-app] Added the retry path` |

Default behavior is untouched — this is opt-in.

- `pkg/jsonl`: `AiTitle` field, `LastAiTitle` (already-parsed messages) and `LastAiTitleFromFile` (streaming, only unmarshals lines containing `"ai-title"` so it stays cheap on multi-MB transcripts).
- `internal/sessionname`: `FromAiTitle` — collapses whitespace, strips `[`, `]` and `|` so a title can't be mistaken for the prefix's own delimiters, caps at 60 runes, falls back to `GenerateSessionLabel`.
- `internal/hooks`: `resolveSessionName` reuses the messages the Stop path already parsed (no extra I/O in the common case); other events fall back to the streaming scan. `sendNotifications` takes the label, empty meaning "generated".
- `internal/config`: option, getter, `Validate` rejects unknown values.

Sessions with no title yet — the first moments of a conversation, and most subagent transcripts — keep the generated label, so there's no blank or ugly fallback.

## Two things worth flagging

- **The label also reaches webhooks.** Same `enhancedMessage` goes to Slack/Telegram/ntfy, so opting in means AI-generated session titles leave the machine. Called out in the README section; it's part of why the default stays `generated`.
- **Titles change mid-session.** Claude rewrites `ai-title` as a conversation moves on; the last entry wins, so a long session's notifications can shift labels. That matches what the terminal tab shows at that moment, which seemed like the right thing to follow.

## Testing

`make lint` and the full `go test ./...` pass. New tests:

- `pkg/jsonl`: title present / absent / empty / last-wins / invalid JSON lines mixed in / missing file / round-trip.
- `internal/sessionname`: plain, delimiters stripped, whitespace collapsed, truncation (incl. multi-byte runes not split), fallback for empty / whitespace-only / delimiters-only.
- `internal/config`: default, explicit values, unknown value defensive fallback, `Validate` accept/reject.
- `internal/hooks`: Stop with a title, Stop without one (falls back), and default source ignoring an existing title.

Happy to adjust the option name, the 60-rune cap, or make the aiTitle-vs-generated choice per-channel (desktop only, keeping webhooks on the generated label) if you'd prefer that split.