### PR TITLE
fix(bootstrap): verify manifest for unknown plugin versions

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -191,9 +191,16 @@ get_installed_plugin_version() {
         PLUGIN_KEY="$PLUGIN_KEY" jq -r '
           (.plugins[env.PLUGIN_KEY] // []) as $entries
           | ($entries | map(select((.installPath // "") != ""))) as $with_paths
-          | (if ($with_paths | length) == 0 then $entries else $with_paths end)
-          | sort_by((.version // "0.0.0") | split(".") | map(tonumber? // 0))
-          | if length == 0 then {} else .[-1] end
+          | (if ($with_paths | length) == 0 then $entries else $with_paths end) as $candidates
+          | ($candidates | map(select(
+              ((.version // "") | ascii_downcase | ltrimstr("v")) as $version
+              | $version == "" or $version == "unknown"
+            ))) as $placeholders
+          | if ($placeholders | length) > 0 then $placeholders[-1]
+            else ($candidates
+              | sort_by((.version // "0.0.0") | split(".") | map(tonumber? // 0))
+              | if length == 0 then {} else .[-1] end)
+            end
           | .version // empty
         ' "$INSTALLED_JSON" 2>/dev/null || true
         return 0
@@ -209,6 +216,11 @@ def ver_tuple(value):
         return tuple(int(p) for p in parts)
     except Exception:
         return (0, 0, 0)
+def is_placeholder(value):
+    normalized = str(value or '').lower()
+    if normalized.startswith('v'):
+        normalized = normalized[1:]
+    return normalized in ('', 'unknown')
 try:
     with open(sys.argv[1]) as f:
         d = json.load(f)
@@ -217,7 +229,8 @@ try:
         with_paths = [e for e in entries if isinstance(e, dict) and e.get('installPath')]
         candidates = with_paths or [e for e in entries if isinstance(e, dict)]
         if candidates:
-            best = max(candidates, key=lambda e: ver_tuple(e.get('version')))
+            placeholders = [e for e in candidates if is_placeholder(e.get('version'))]
+            best = placeholders[-1] if placeholders else max(candidates, key=lambda e: ver_tuple(e.get('version')))
             print(best.get('version', '') or '')
 except Exception:
     pass
@@ -245,6 +258,10 @@ function compareVersions(a, b) {
   }
   return 0;
 }
+function isPlaceholder(value) {
+  const normalized = String(value || '').toLowerCase().replace(/^v/, '');
+  return normalized === '' || normalized === 'unknown';
+}
 try {
   const installedPath = process.argv[2];
   const pluginKey = process.env.PLUGIN_KEY;
@@ -253,7 +270,10 @@ try {
   const candidates = entries.filter((entry) => entry.installPath) || entries;
   const pool = candidates.length > 0 ? candidates : entries;
   if (pool.length > 0) {
-    const best = pool.slice().sort(compareVersions).pop();
+    const placeholders = pool.filter((entry) => isPlaceholder(entry.version));
+    const best = placeholders.length > 0
+      ? placeholders[placeholders.length - 1]
+      : pool.slice().sort(compareVersions).pop();
     process.stdout.write(String((best && best.version) || ''));
   }
 } catch (_) {}
@@ -273,9 +293,16 @@ get_installed_plugin_root() {
     if command -v jq &>/dev/null; then
         PLUGIN_KEY="$PLUGIN_KEY" jq -r '
           (.plugins[env.PLUGIN_KEY] // [])
-          | map(select((.installPath // "") != ""))
-          | sort_by((.version // "0.0.0") | split(".") | map(tonumber? // 0))
-          | if length == 0 then {} else .[-1] end
+          | map(select((.installPath // "") != "")) as $candidates
+          | ($candidates | map(select(
+              ((.version // "") | ascii_downcase | ltrimstr("v")) as $version
+              | $version == "" or $version == "unknown"
+            ))) as $placeholders
+          | if ($placeholders | length) > 0 then $placeholders[-1]
+            else ($candidates
+              | sort_by((.version // "0.0.0") | split(".") | map(tonumber? // 0))
+              | if length == 0 then {} else .[-1] end)
+            end
           | .installPath // empty
         ' "$INSTALLED_JSON" 2>/dev/null || true
         return 0
@@ -291,13 +318,19 @@ def ver_tuple(value):
         return tuple(int(p) for p in parts)
     except Exception:
         return (0, 0, 0)
+def is_placeholder(value):
+    normalized = str(value or '').lower()
+    if normalized.startswith('v'):
+        normalized = normalized[1:]
+    return normalized in ('', 'unknown')
 try:
     with open(sys.argv[1]) as f:
         d = json.load(f)
     entries = d.get('plugins', {}).get(sys.argv[2], [])
     candidates = [e for e in entries if isinstance(e, dict) and e.get('installPath')]
     if candidates:
-        best = max(candidates, key=lambda e: ver_tuple(e.get('version')))
+        placeholders = [e for e in candidates if is_placeholder(e.get('version'))]
+        best = placeholders[-1] if placeholders else max(candidates, key=lambda e: ver_tuple(e.get('version')))
         print(best.get('installPath', '') or '')
 except Exception:
     pass
@@ -325,6 +358,10 @@ function compareVersions(a, b) {
   }
   return 0;
 }
+function isPlaceholder(value) {
+  const normalized = String(value || '').toLowerCase().replace(/^v/, '');
+  return normalized === '' || normalized === 'unknown';
+}
 try {
   const installedPath = process.argv[2];
   const pluginKey = process.env.PLUGIN_KEY;
@@ -332,7 +369,10 @@ try {
   const entries = ((data.plugins || {})[pluginKey] || [])
     .filter((entry) => entry && typeof entry === 'object' && entry.installPath);
   if (entries.length > 0) {
-    const best = entries.slice().sort(compareVersions).pop();
+    const placeholders = entries.filter((entry) => isPlaceholder(entry.version));
+    const best = placeholders.length > 0
+      ? placeholders[placeholders.length - 1]
+      : entries.slice().sort(compareVersions).pop();
     process.stdout.write(String((best && best.installPath) || ''));
   }
 } catch (_) {}
@@ -441,7 +481,7 @@ verify_installed_plugin_version() {
     # Claude Code can record a successfully installed plugin with an unknown or
     # empty registry version. In that case, verify the files at the selected
     # installPath instead of treating the registry placeholder as authoritative.
-    case "$installed_version" in
+    case "${installed_version#v}" in
         ""|unknown)
             local installed_root=""
             local manifest_version=""
@@ -524,10 +564,12 @@ install_plugin() {
     expected_version=$(get_manifest_version "$MARKETPLACE_PLUGIN_JSON")
 
     local installed_before=""
+    local installed_root_before=""
     installed_before=$(get_installed_plugin_version)
+    installed_root_before=$(get_installed_plugin_root)
 
     local output
-    if [ -n "$installed_before" ]; then
+    if [ -n "$installed_before" ] || [ -n "$installed_root_before" ]; then
         if output=$(claude plugin update "$PLUGIN_KEY" </dev/null 2>&1); then
             echo -e "${GREEN}✓${NC} Plugin updated"
         else

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -434,7 +434,27 @@ verify_installed_plugin_version() {
 
     local installed_version=""
     installed_version=$(get_installed_plugin_version)
-    [ "$installed_version" = "$expected_version" ]
+    if [ "$installed_version" = "$expected_version" ]; then
+        return 0
+    fi
+
+    # Claude Code can record a successfully installed plugin with an unknown or
+    # empty registry version. In that case, verify the files at the selected
+    # installPath instead of treating the registry placeholder as authoritative.
+    case "$installed_version" in
+        ""|unknown)
+            local installed_root=""
+            local manifest_version=""
+            installed_root=$(get_installed_plugin_root)
+            if [ -n "$installed_root" ]; then
+                manifest_version=$(get_manifest_version "${installed_root}/.claude-plugin/plugin.json")
+            fi
+            [ "$manifest_version" = "$expected_version" ]
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 # ──────────────────────────────────────────────

--- a/bin/install_e2e_test.sh
+++ b/bin/install_e2e_test.sh
@@ -99,6 +99,20 @@ run_bootstrap_version_verification() {
         _ "$sourceable_bootstrap" "$expected_version"
 }
 
+run_bootstrap_install_plugin() {
+    local claude_home="$1"
+    local sourceable_bootstrap="$2"
+    local command_log="$3"
+
+    CLAUDE_CONFIG_DIR="$claude_home" COMMAND_LOG="$command_log" bash -c '
+        source "$1"
+        claude() {
+            printf "%s\n" "$*" >> "$COMMAND_LOG"
+        }
+        install_plugin
+    ' _ "$sourceable_bootstrap"
+}
+
 # Get normalized platform name (matching install.sh)
 get_platform() {
     local os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -512,6 +526,25 @@ EOF
     exit_code=$?
     assert_exit_code 0 "$exit_code" "Bootstrap accepts the installed manifest when the registry version is empty"
 
+    write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "vunknown" "$plugin_root"
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 0 "$exit_code" "Bootstrap accepts the installed manifest when the registry version is vunknown"
+
+    cat > "$claude_home/plugins/installed_plugins.json" <<EOF
+{
+  "plugins": {
+    "claude-notifications-go@claude-notifications-go": [
+      {"version": "1.39.0", "installPath": "$claude_home/plugins/cache/claude-notifications-go/claude-notifications-go/1.39.0"},
+      {"version": "unknown", "installPath": "$plugin_root"}
+    ]
+  }
+}
+EOF
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 0 "$exit_code" "Bootstrap verifies the path paired with a current unknown entry before older numeric versions"
+
     write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "1.39.0" "$plugin_root"
     run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
     exit_code=$?
@@ -529,6 +562,37 @@ EOF
     run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
     exit_code=$?
     assert_exit_code 1 "$exit_code" "Bootstrap rejects an unknown registry version without an installed manifest"
+
+    cleanup_test_dir
+}
+
+test_bootstrap_empty_registry_version_preserves_installed_manifest() {
+    echo -e "\n${CYAN}▶ test_bootstrap_empty_registry_version_preserves_installed_manifest${NC}"
+    setup_test_dir
+
+    local claude_home="$TEST_DIR/claude"
+    local plugin_root="$claude_home/plugins/cache/claude-notifications-go/claude-notifications-go/1.40.1"
+    local marketplace_manifest="$claude_home/plugins/marketplaces/claude-notifications-go/.claude-plugin/plugin.json"
+    local sourceable_bootstrap="$TEST_DIR/bootstrap-functions.sh"
+    local command_log="$TEST_DIR/claude-commands.log"
+    mkdir -p "$claude_home/plugins" "$plugin_root/.claude-plugin" "$(dirname "$marketplace_manifest")"
+
+    sed '/^main "\$@"$/d' "$SCRIPT_DIR/bootstrap.sh" > "$sourceable_bootstrap"
+    write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "" "$plugin_root"
+    cat > "$plugin_root/.claude-plugin/plugin.json" <<'EOF'
+{"name":"claude-notifications-go","version":"1.40.1"}
+EOF
+    cat > "$marketplace_manifest" <<'EOF'
+{"name":"claude-notifications-go","version":"1.40.1"}
+EOF
+
+    local exit_code
+    run_bootstrap_install_plugin "$claude_home" "$sourceable_bootstrap" "$command_log"
+    exit_code=$?
+    assert_exit_code 0 "$exit_code" "Bootstrap keeps a path-bearing empty-version installation"
+    assert_file_exists "$plugin_root/.claude-plugin/plugin.json" "Bootstrap does not clear the manifest before verification"
+    assert_contains "$(cat "$command_log")" "plugin update" "Bootstrap updates a path-bearing empty-version installation"
+    assert_not_contains "$(cat "$command_log")" "plugin install" "Bootstrap avoids an unnecessary reinstall for an empty registry version"
 
     cleanup_test_dir
 }
@@ -2284,6 +2348,7 @@ main() {
         test_binary_name_format
         test_wsl_guard_blocks_linux_install
         test_bootstrap_version_verification_uses_installed_manifest_for_unknown_registry
+        test_bootstrap_empty_registry_version_preserves_installed_manifest
         test_lock_created
         test_lock_prevents_parallel
         test_lock_stale_removal

--- a/bin/install_e2e_test.sh
+++ b/bin/install_e2e_test.sh
@@ -73,6 +73,32 @@ cleanup_test_dir() {
     fi
 }
 
+write_installed_plugin_registry() {
+    local output_path="$1"
+    local version="$2"
+    local install_path="$3"
+
+    cat > "$output_path" <<EOF
+{
+  "plugins": {
+    "claude-notifications-go@claude-notifications-go": [
+      {"version": "$version", "installPath": "$install_path"}
+    ]
+  }
+}
+EOF
+}
+
+run_bootstrap_version_verification() {
+    local claude_home="$1"
+    local sourceable_bootstrap="$2"
+    local expected_version="$3"
+
+    CLAUDE_CONFIG_DIR="$claude_home" bash -c \
+        'source "$1"; verify_installed_plugin_version "$2"' \
+        _ "$sourceable_bootstrap" "$expected_version"
+}
+
 # Get normalized platform name (matching install.sh)
 get_platform() {
     local os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -455,6 +481,54 @@ UNAME_EOF
     assert_contains "$output" "Git Bash" "Windows Git Bash guidance shown"
     assert_not_contains "$output" "Platform:" "WSL guard stops before platform output"
     assert_dir_not_exists "$TEST_DIR/.install.lock" "WSL guard stops before acquiring install lock"
+
+    cleanup_test_dir
+}
+
+test_bootstrap_version_verification_uses_installed_manifest_for_unknown_registry() {
+    echo -e "\n${CYAN}▶ test_bootstrap_version_verification_uses_installed_manifest_for_unknown_registry${NC}"
+    setup_test_dir
+
+    local claude_home="$TEST_DIR/claude"
+    local plugin_root="$claude_home/plugins/cache/claude-notifications-go/claude-notifications-go/1.40.1"
+    local sourceable_bootstrap="$TEST_DIR/bootstrap-functions.sh"
+    mkdir -p "$claude_home/plugins" "$plugin_root/.claude-plugin"
+
+    # Load the production helpers without executing bootstrap's main function.
+    sed '/^main "\$@"$/d' "$SCRIPT_DIR/bootstrap.sh" > "$sourceable_bootstrap"
+
+    write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "unknown" "$plugin_root"
+    cat > "$plugin_root/.claude-plugin/plugin.json" <<'EOF'
+{"name":"claude-notifications-go","version":"1.40.1"}
+EOF
+
+    local exit_code
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 0 "$exit_code" "Bootstrap accepts the installed manifest when the registry version is unknown"
+
+    write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "" "$plugin_root"
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 0 "$exit_code" "Bootstrap accepts the installed manifest when the registry version is empty"
+
+    write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "1.39.0" "$plugin_root"
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 1 "$exit_code" "Bootstrap preserves explicit registry version mismatch failures"
+
+    write_installed_plugin_registry "$claude_home/plugins/installed_plugins.json" "unknown" "$plugin_root"
+    cat > "$plugin_root/.claude-plugin/plugin.json" <<'EOF'
+{"name":"claude-notifications-go","version":"1.39.0"}
+EOF
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 1 "$exit_code" "Bootstrap rejects an unknown registry version when the installed manifest is stale"
+
+    rm -f "$plugin_root/.claude-plugin/plugin.json"
+    run_bootstrap_version_verification "$claude_home" "$sourceable_bootstrap" "1.40.1"
+    exit_code=$?
+    assert_exit_code 1 "$exit_code" "Bootstrap rejects an unknown registry version without an installed manifest"
 
     cleanup_test_dir
 }
@@ -2209,6 +2283,7 @@ main() {
         test_platform_detection
         test_binary_name_format
         test_wsl_guard_blocks_linux_install
+        test_bootstrap_version_verification_uses_installed_manifest_for_unknown_registry
         test_lock_created
         test_lock_prevents_parallel
         test_lock_stale_removal


### PR DESCRIPTION
## Summary

- fall back to the installed plugin manifest when Claude Code records the registry version as `unknown` or empty
- keep explicit registry mismatches and stale or missing manifests fail-closed
- add offline coverage for the successful fallback and its negative controls

Fixes #132

## Root cause

`verify_installed_plugin_version` treated `installed_plugins.json` as the only version authority. Claude Code can persist a valid `installPath` while leaving its `version` as `unknown`, so bootstrap reinstalled the plugin and then reported the same mismatch even though the installed manifest matched the marketplace version.

## Testing

- `bash bin/install_e2e_test.sh` — 96 passed, 12 expected skips
- `make test-race`
- `make lint`
- `bash -n bin/bootstrap.sh bin/install_e2e_test.sh`
- `git diff --check`

## AI assistance

This change was prepared with Codex assistance and independently reviewed against the registry, manifest, and Git Bash fallback paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin version selection when registry entries are empty or marked unknown.
  - Installations now verify the selected plugin’s manifest version when registry data is unavailable.
  - Plugin updates proceed when an installed version or installation location is present.
  - Version mismatches, stale manifests, and missing manifests continue to be rejected.
  - Empty registry versions no longer overwrite a valid installed manifest.

- **Tests**
  - Added offline coverage for unknown, empty, mismatched, stale, and missing version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->