### PR TITLE
feat(notifier): make the session label in the title optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Edit the config file directly:
       "audioDevice": "",
       "clickToFocus": true,
       "terminalBundleId": "",
+      "showSessionLabel": true,
       "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
     },
     "webhook": {
@@ -277,6 +278,7 @@ Edit the config file directly:
 | `notifyOnSubagentStop` | `false` | Send notifications when subagents (Task tool) complete. Has no effect unless `suppressForSubagents` is also set to `false`. |
 | `suppressForSubagents` | `true` | Suppress subagent (`SubagentStop`) notifications, plus any `Stop` notification whose transcript is a subagent/teammate transcript. Detection uses the hook event for `SubagentStop` (Claude Code passes the parent session `transcript_path` to that hook, so a path check alone can't identify it). Set to `false` together with `notifyOnSubagentStop: true` to get a notification each time a subagent finishes. |
 | `notifyOnTextResponse` | `true` | Send notifications for text-only responses (no tool usage) |
+| `desktop.showSessionLabel` | `true` | Append the `[name id]` session label to the notification title. |
 | `respectJudgeMode` | `true` | Honor `CLAUDE_HOOK_JUDGE_MODE=true` env var to suppress notifications |
 | `notifyOnlyWhenUnfocused` | `false` | Skip the desktop notification only when the focused terminal window can be matched to the current Claude Code session. Best-effort per platform; if focus can't be determined the notification is still shown. |
 | `notifyDelaySeconds` | `0` | Wait N seconds before delivering a desktop notification (capped at 25s by the hook timeout). With `notifyOnlyWhenUnfocused`, focus is re-checked after the wait. Webhooks are unaffected. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type DesktopConfig struct {
 	AudioDevice      string  `json:"audioDevice"`      // Audio output device name (empty = system default)
 	AppIcon          string  `json:"appIcon"`          // Path to app icon
 	ClickToFocus     bool    `json:"clickToFocus"`     // macOS/Linux/Windows: activate the originating terminal window on notification click (default: true)
+	ShowSessionLabel *bool   `json:"showSessionLabel"` // Include the "[name id]" session label in the notification title (default: true)
 	TerminalBundleID string  `json:"terminalBundleId"` // macOS: override auto-detected terminal bundle ID (empty = auto)
 }
 
@@ -710,6 +711,15 @@ func (c *Config) IsTerminalBellEnabled() bool {
 		return true // Default: enabled
 	}
 	return *c.Notifications.Desktop.TerminalBell
+}
+
+// IsSessionLabelEnabled returns true if the session label should be appended to the
+// notification title (default: true)
+func (c *Config) IsSessionLabelEnabled() bool {
+	if c.Notifications.Desktop.ShowSessionLabel == nil {
+		return true // Default: enabled
+	}
+	return *c.Notifications.Desktop.ShowSessionLabel
 }
 
 // IsStatusDesktopEnabled returns true if desktop notifications for this status are enabled

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -816,6 +816,71 @@ func TestIsTerminalBellEnabled(t *testing.T) {
 	assert.False(t, cfg.IsTerminalBellEnabled(), "TerminalBell should be false when set to false")
 }
 
+func TestIsSessionLabelEnabled(t *testing.T) {
+	// Default (nil) should be true
+	cfg := DefaultConfig()
+	assert.True(t, cfg.IsSessionLabelEnabled(), "ShowSessionLabel should be true by default (nil)")
+
+	// Explicitly true
+	labelOn := true
+	cfg.Notifications.Desktop.ShowSessionLabel = &labelOn
+	assert.True(t, cfg.IsSessionLabelEnabled(), "ShowSessionLabel should be true when set to true")
+
+	// Explicitly false
+	labelOff := false
+	cfg.Notifications.Desktop.ShowSessionLabel = &labelOff
+	assert.False(t, cfg.IsSessionLabelEnabled(), "ShowSessionLabel should be false when set to false")
+}
+
+func TestLoadConfig_ShowSessionLabel(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Test explicit showSessionLabel: false
+	configJSON := `{
+		"notifications": {
+			"desktop": {
+				"enabled": true,
+				"sound": true,
+				"showSessionLabel": false
+			}
+		}
+	}`
+
+	err := os.WriteFile(configPath, []byte(configJSON), 0644)
+	require.NoError(t, err)
+
+	cfg, err := Load(configPath)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Notifications.Desktop.ShowSessionLabel)
+	assert.False(t, cfg.IsSessionLabelEnabled(), "ShowSessionLabel should be false when explicitly set")
+}
+
+func TestLoadConfig_ShowSessionLabel_DefaultWhenNotSpecified(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Config without showSessionLabel - existing installs keep the label
+	configJSON := `{
+		"notifications": {
+			"desktop": {
+				"enabled": true,
+				"sound": true
+			}
+		}
+	}`
+
+	err := os.WriteFile(configPath, []byte(configJSON), 0644)
+	require.NoError(t, err)
+
+	cfg, err := Load(configPath)
+	require.NoError(t, err)
+
+	assert.Nil(t, cfg.Notifications.Desktop.ShowSessionLabel)
+	assert.True(t, cfg.IsSessionLabelEnabled(), "ShowSessionLabel should default to true")
+}
+
 func TestLoadConfig_ClickToFocus(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.json")

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -98,7 +98,7 @@ func (n *Notifier) SendDesktop(status analyzer.Status, message, sessionID, cwd s
 	// Build clean title (status only + session name)
 	// Format: "✅ Completed [peak]" or "✅ Completed"
 	title := statusInfo.Title
-	if sessionName != "" {
+	if sessionName != "" && n.cfg.IsSessionLabelEnabled() {
 		title = fmt.Sprintf("%s [%s]", title, sessionName)
 	}
 


### PR DESCRIPTION
The desktop notification title always appends a "[name id]" session label, with no way to turn it off. At typical notification widths the label competes with the branch/folder subtitle, which is often the more useful identifier.

Add `desktop.showSessionLabel` (default true, so existing installs are unchanged). When false, the title is the bare status text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a desktop notification setting to show or hide session labels in notification titles.
  - Session labels are shown by default for backward compatibility.
  - Documented the new configuration option and its default behavior.

- **Bug Fixes**
  - Notification titles now respect the session-label display setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->